### PR TITLE
HTML version of API documentation (docstrings)

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -31,6 +31,8 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install sphinx
+        cd ${GITHUB_WORKSPACE}/main
+        python -m pip install '.[all]'
 
     - name: Build
       run: |

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -22,6 +22,7 @@ jobs:
     - name: Prepare LaTeX env
       run: |
         sudo apt update
+        sudo apt install openmpi-bin libopenmpi-dev
         sudo apt install \
           texlive-latex-recommended texlive-latex-extra texlive-xetex \
           texlive-lang-japanese texlive-fonts-recommended texlive-fonts-extra latexmk

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -34,8 +34,5 @@ jobs:
 
     - name: Build
       run: |
-        for lang in ja en; do
-          cd ${GITHUB_WORKSPACE}/main/doc/${lang}
-          make html
-          make latexpdf
-        done
+        cd ${GITHUB_WORKSPACE}/main/doc
+        sh ./make.sh

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -37,6 +37,7 @@ jobs:
     - name: Prepare LaTeX env
       run: |
         sudo apt update
+          sudo apt install openmpi-bin libopenmpi-dev
         sudo apt install \
           texlive-latex-recommended texlive-latex-extra texlive-xetex \
           texlive-lang-japanese texlive-fonts-recommended texlive-fonts-extra latexmk

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -49,6 +49,8 @@ jobs:
 
     - name: Build
       run: |
+        cd ${GITHUB_WORKSPACE}/main
+        python -m pip install '.[all]'
         cd ${GITHUB_WORKSPACE}/main/doc
         sh ./make.sh --latex
 

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - deploy_api_docs
       # - develop
       # - ghactions
       # - '*-autodoc'
@@ -48,11 +49,8 @@ jobs:
 
     - name: Build
       run: |
-        for lang in ja en; do
-          cd ${GITHUB_WORKSPACE}/main/doc/${lang}
-          make html
-          make latexpdf
-        done
+        cd ${GITHUB_WORKSPACE}/main/doc
+        sh ./make.sh --latex
 
     - name: Deploy Configuration
       run: |
@@ -71,6 +69,8 @@ jobs:
           is_tag=NO
           TARGET_NAME="${TARGET_NAME%-autodoc}"
           test "_$(echo ${GITHUB_REF:-'//'} | cut -d/ -f2)" = "_tags" && is_tag=YES
+
+          # JA & EN manuals
           for lang in ja en; do
             rm -rf "gh-pages/manual/${TARGET_NAME}/${lang}"
             mkdir -p "gh-pages/manual/${TARGET_NAME}"
@@ -80,6 +80,12 @@ jobs:
               :
             fi
           done
+
+          # API manual
+          rm -rf "gh-pages/manual/${TARGET_NAME}/api"
+          mkdir -p "gh-pages/manual/${TARGET_NAME}"
+          cp -r "main/doc/api/build/html" "gh-pages/manual/${TARGET_NAME}/api"
+
           cd gh-pages
           git config --local user.name "${GIT_USER}"
           git config --local user.email "${GIT_EMAIL}"

--- a/doc/api/Makefile
+++ b/doc/api/Makefile
@@ -17,4 +17,4 @@ help:
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
-	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" -W $(SPHINXOPTS) $(O)
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/doc/api/make.bat
+++ b/doc/api/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=source
+set BUILDDIR=build
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/doc/api/source/.gitignore
+++ b/doc/api/source/.gitignore
@@ -1,0 +1,2 @@
+odatse*.rst
+modules.rst

--- a/doc/api/source/conf.py
+++ b/doc/api/source/conf.py
@@ -1,0 +1,46 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+import sys
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+project = 'ODAT-SE API'
+copyright = '2020-, ISSP, UTokyo'
+author = '2DMAT Developers'
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+sys.path.insert(0, "../../src")
+
+extensions = [
+    "sphinx.ext.autodoc",
+    "sphinx.ext.viewcode",
+    "sphinx.ext.todo",
+    "sphinx.ext.napoleon",
+]
+
+templates_path = ['_templates']
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = "haiku"
+html_static_path = ['_static']
+
+# -- Options for todo extension ----------------------------------------------
+
+# If true, `todo` and `todoList` produce output, else they produce nothing.
+todo_include_todos = True
+
+autoclass_content = 'both'
+
+napoleon_include_init_with_doc = True
+

--- a/doc/api/source/index.rst
+++ b/doc/api/source/index.rst
@@ -1,0 +1,21 @@
+.. ODAT-SE API documentation master file, created by
+   sphinx-quickstart on Thu Oct 31 10:18:29 2024.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to ODAT-SE API's documentation!
+=======================================
+
+.. toctree::
+   :maxdepth: 4
+   :caption: Contents:
+
+   odatse
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/doc/make.sh
+++ b/doc/make.sh
@@ -1,0 +1,29 @@
+if [ "_$1" == "_--latex" ]; then
+  BUILD_LATEX=ON
+  latexmk --version > /dev/null 2>&1 || { echo "Latexmk is not installed"; exit 1; }
+else
+  BUILD_LATEX=OFF
+fi
+
+sphinx-build --version > /dev/null 2>&1 || { echo "Sphinx is not installed"; exit 1; }
+
+DOCROOT=`pwd`
+
+# user's manual
+cd ${DOCROOT}/ja
+make html
+if [ $BUILD_LATEX = "ON" ]; then
+  make latexpdf
+fi
+
+cd ${DOCROOT}/en
+make html
+if [ $BUILD_LATEX = "ON" ]; then
+  make latexpdf
+fi
+
+# api
+cd $DOCROOT
+sphinx-apidoc -P -f -e -o ./api/source ../src/odatse/
+cd api
+make html


### PR DESCRIPTION
A sample is available at
https://issp-center-dev.github.io/ODAT-SE/manual/deploy_api_docs/api/index.html

After merged into the main branch, the latest version of API references will be uploaded to
https://issp-center-dev.github.io/ODAT-SE/manual/deploy_api_docs/api/index.html

To make all the documents including the API reference,  run the `make.sh` script in the `doc/` directory.