### PR TITLE
Remove deprecated typing classes

### DIFF
--- a/doc/en/source/customize/algorithm.rst
+++ b/doc/en/source/customize/algorithm.rst
@@ -40,7 +40,7 @@
 
     - ``self.dimension: int`` : the dimension of the parameter space
 
-    - ``self.label_list: List[str]`` : the name of each axes of the parameter space
+    - ``self.label_list: list[str]`` : the name of each axes of the parameter space
 
     - ``self.root_dir: pathlib.Path`` : root directory
 
@@ -86,13 +86,13 @@
 
     - It should be called after ``self.prepare()`` is called.
 
-- ``post(self) -> Dict``
+- ``post(self) -> dict``
 
     - Runs a post process of the algorithm, for example, writing the results into files.
     - Enters into ``self.output_dir``, calls ``self._post()``, and returns to the original directory.
     - It should be called after ``self.run()`` is called.
 
-- ``main(self, run_mode) -> Dict``
+- ``main(self, run_mode) -> dict``
 
     - Calls ``prepare``, ``run``, and ``post``.
     - Measures the elapsed times for calling functions, and writes them into a file
@@ -140,7 +140,7 @@ It is defined as a subclass of ``AlgorithmBase`` and should have the following m
 	 args = (step, set)
          fx = self.runner.submit(x, args)
 
-- ``_post(self) -> Dict``
+- ``_post(self) -> dict``
 
     - Describes post-process of the algorithm.
 

--- a/doc/ja/source/customize/algorithm.rst
+++ b/doc/ja/source/customize/algorithm.rst
@@ -56,7 +56,7 @@
             - ディレクトリが存在しない場合、自動的に作成されます
             - 各プロセスで最適化アルゴリズムはこのディレクトリで実行されます
 
-        - ``self.timer: Dict[str, Dict]`` : 実行時間を保存するための辞書
+        - ``self.timer: dict[str, dict]`` : 実行時間を保存するための辞書
 
             - 空の辞書が3つ、 ``"prepare"``, ``"run"``, ``"post"`` という名前で定義されます
 
@@ -85,13 +85,13 @@
       #. 元のディレクトリに戻る
     - ``self.prepare()`` の後に実行する必要があります
 
-- ``post(self) -> Dict``
+- ``post(self) -> dict``
 
     - 最適化結果のファイル出力など、後処理を行います
     - ``self.output_dir`` に移動し、 ``self._post()`` を実行した後、元のディレクトリに戻ります
     - ``self.run()`` のあとに実行する必要があります
 
-- ``main(self, run_mode) -> Dict``
+- ``main(self, run_mode) -> dict``
 
     - ``prepare``, ``run``, ``post`` を順番に実行します
     - それぞれの関数でかかった時間を計測し、結果をファイル出力します
@@ -138,7 +138,7 @@
 	 args = (step, set)
          fx = self.runner.submit(x, args)
 
-- ``_post(self) -> Dict``
+- ``_post(self) -> dict``
 
     - 最適化アルゴリズムの後処理を記述します
     - 探索の結果を辞書形式で返します

--- a/src/odatse/_info.py
+++ b/src/odatse/_info.py
@@ -6,7 +6,8 @@
 # This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
 # If a copy of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from typing import MutableMapping, Optional
+from collections.abc import MutableMapping
+from typing import Optional
 from pathlib import Path
 from fnmatch import fnmatch
 

--- a/src/odatse/_runner.py
+++ b/src/odatse/_runner.py
@@ -19,7 +19,7 @@ from odatse.exception import InputError
 
 # type hints
 from pathlib import Path
-from typing import List, Optional
+from typing import Optional
 from . import mpi
 
 

--- a/src/odatse/algorithm/_algorithm.py
+++ b/src/odatse/algorithm/_algorithm.py
@@ -24,7 +24,7 @@ from odatse import exception, mpi
 
 # for type hints
 from pathlib import Path
-from typing import List, Optional, TYPE_CHECKING, Dict, Tuple
+from typing import Optional, TYPE_CHECKING
 
 
 if TYPE_CHECKING:
@@ -44,14 +44,14 @@ class AlgorithmBase(metaclass=ABCMeta):
     mpirank: int
     rng: np.random.RandomState
     dimension: int
-    label_list: List[str]
+    label_list: list[str]
     runner: Optional[odatse.Runner]
 
     root_dir: Path
     output_dir: Path
     proc_dir: Path
 
-    timer: Dict[str, Dict]
+    timer: dict[str, dict]
 
     status: AlgorithmStatus = AlgorithmStatus.INIT
     mode: Optional[str] = None
@@ -195,13 +195,13 @@ class AlgorithmBase(metaclass=ABCMeta):
         """Abstract method to be implemented by subclasses for running steps."""
         pass
 
-    def post(self) -> Dict:
+    def post(self) -> dict:
         """
         Perform post-processing after the algorithm has run.
 
         Returns
         -------
-        Dict
+        dict
             Dictionary containing post-processing results.
         """
         if self.status < AlgorithmStatus.RUN:
@@ -214,7 +214,7 @@ class AlgorithmBase(metaclass=ABCMeta):
         return result
 
     @abstractmethod
-    def _post(self) -> Dict:
+    def _post(self) -> dict:
         """Abstract method to be implemented by subclasses for post-processing steps."""
         pass
 
@@ -304,7 +304,7 @@ class AlgorithmBase(metaclass=ABCMeta):
         shutil.move(Path(filename + ".tmp"), Path(filename))
         print("save_state: write to {}".format(filename))
 
-    def _load_data(self, filename="state.pickle") -> Dict:
+    def _load_data(self, filename="state.pickle") -> dict:
         """
         Load data from a file.
 
@@ -315,7 +315,7 @@ class AlgorithmBase(metaclass=ABCMeta):
 
         Returns
         -------
-        Dict
+        dict
             Dictionary containing the loaded data.
         """
         if Path(filename).exists():

--- a/src/odatse/algorithm/bayes.py
+++ b/src/odatse/algorithm/bayes.py
@@ -6,7 +6,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
 # If a copy of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from typing import List, Optional, TYPE_CHECKING
+from typing import Optional, TYPE_CHECKING
 import time
 import copy
 from pathlib import Path
@@ -29,7 +29,7 @@ class Algorithm(odatse.algorithm.AlgorithmBase):
     ----------
     mesh_list : np.ndarray
         The mesh grid list.
-    label_list : List[str]
+    label_list : list[str]
         The list of labels.
     random_max_num_probes : int
         The maximum number of random probes.
@@ -43,13 +43,13 @@ class Algorithm(odatse.algorithm.AlgorithmBase):
         The number of random basis.
     xopt : np.ndarray
         The optimal solution.
-    best_fx : List[float]
+    best_fx : list[float]
         The list of best function values.
-    best_action : List[int]
+    best_action : list[int]
         The list of best actions.
-    fx_list : List[float]
+    fx_list : list[float]
         The list of function values.
-    param_list : List[np.ndarray]
+    param_list : list[np.ndarray]
         The list of parameters.
     """
 

--- a/src/odatse/algorithm/exchange.py
+++ b/src/odatse/algorithm/exchange.py
@@ -6,7 +6,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
 # If a copy of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from typing import Dict, Optional, TYPE_CHECKING
+from typing import Optional, TYPE_CHECKING
 
 from io import open
 import copy
@@ -284,6 +284,7 @@ class Algorithm(odatse.algorithm.montecarlo.AlgorithmBase):
             If False, attempt exchanges between odd-even pairs.
         """
         if self.mpisize > 1:
+            assert self.mpicomm is not None
             self.mpicomm.Barrier()
         if direction:
             if self.Tindex[0] % 2 == 0:
@@ -398,7 +399,7 @@ class Algorithm(odatse.algorithm.montecarlo.AlgorithmBase):
         self.timer["run"]["submit"] = 0.0
         self.timer["run"]["exchange"] = 0.0
 
-    def _post(self) -> Dict:
+    def _post(self) -> dict:
         """
         Post-process the results of the algorithm.
         """
@@ -429,6 +430,7 @@ class Algorithm(odatse.algorithm.montecarlo.AlgorithmBase):
 
         # Gather best results from all processes
         if self.mpisize > 1:
+            assert self.mpicomm is not None
             # NOTE:
             # ``gather`` seems not to work with many processes (say, 32) in some MPI implementation.
             # ``Gather`` and ``allgather`` seem to work fine.

--- a/src/odatse/algorithm/gather.py
+++ b/src/odatse/algorithm/gather.py
@@ -6,7 +6,6 @@
 # This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
 # If a copy of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from typing import List, Dict, Union
 
 import os
 import numpy as np

--- a/src/odatse/algorithm/mapper_mpi.py
+++ b/src/odatse/algorithm/mapper_mpi.py
@@ -6,7 +6,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
 # If a copy of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from typing import List, Union, Dict, Optional, TYPE_CHECKING
+from typing import Union, Optional, TYPE_CHECKING
 
 from pathlib import Path
 from io import open
@@ -23,7 +23,7 @@ class Algorithm(MapperMPIAlgorithm):
     Algorithm class for data analysis of quantum beam diffraction experiments.
     Inherits from odatse.algorithm.AlgorithmBase.
     """
-    mesh_list: List[Union[int, float]]
+    mesh_list: list[Union[int, float]]
 
     def __init__(
         self,

--- a/src/odatse/algorithm/mapper_mpi_base.py
+++ b/src/odatse/algorithm/mapper_mpi_base.py
@@ -6,7 +6,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
 # If a copy of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from typing import List, Union, Dict, Optional
+from typing import Union, Optional
 
 from pathlib import Path
 from io import open
@@ -23,7 +23,7 @@ class Algorithm(AlgorithmBase):
     Algorithm class for data analysis of quantum beam diffraction experiments.
     Inherits from odatse.algorithm.AlgorithmBase.
     """
-    mesh_list: List[Union[int, float]]
+    mesh_list: list[Union[int, float]]
 
     def __init__(self, info: odatse.Info,
                  runner: Optional[odatse.Runner] = None,
@@ -172,13 +172,13 @@ class Algorithm(AlgorithmBase):
         """
         pass
 
-    def _post(self) -> Dict:
+    def _post(self) -> dict:
         """
         Post-process the results and gather data from all MPI ranks.
 
         Returns
         -------
-        Dict
+        dict
             Dictionary of results.
         """
         if self.mpisize > 1:

--- a/src/odatse/algorithm/min_search.py
+++ b/src/odatse/algorithm/min_search.py
@@ -6,7 +6,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
 # If a copy of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from typing import List, Union, Optional, TYPE_CHECKING
+from typing import Union, Optional, TYPE_CHECKING
 import time
 
 import numpy as np
@@ -33,7 +33,7 @@ class Algorithm(odatse.algorithm.AlgorithmBase):
     unit_list: np.ndarray
 
     # hyperparameters of Nelder-Mead
-    initial_simplex_list: List[List[float]]
+    initial_simplex_list: list[list[float]]
     xtol: float
     ftol: float
 
@@ -42,10 +42,10 @@ class Algorithm(odatse.algorithm.AlgorithmBase):
     fopt: float
     itera: int
     funcalls: int
-    allvecs: List[np.ndarray]
+    allvecs: list[np.ndarray]
 
-    iter_history: List[List[Union[int,float]]]
-    fev_history: List[List[Union[int,float]]]
+    iter_history: list[list[Union[int, float]]]
+    fev_history: list[list[Union[int, float]]]
 
     def __init__(
         self,

--- a/src/odatse/algorithm/montecarlo.py
+++ b/src/odatse/algorithm/montecarlo.py
@@ -7,7 +7,7 @@
 # If a copy of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import typing
-from typing import TextIO, Union, List, Tuple, Optional, TYPE_CHECKING
+from typing import Union, Optional, TYPE_CHECKING
 import copy
 import time
 from pathlib import Path
@@ -80,7 +80,7 @@ class AlgorithmBase(odatse.algorithm.AlgorithmBase):
     # inode: np.ndarray
     # nnodes: int
     # node_coordinates: np.ndarray
-    # neighbor_list: List[List[int]]
+    # neighbor_list: list[list[int]]
     # ncandidates: np.ndarray  # len(neighbor_list[i])-1
 
     # state: Union[ContinuousState, DiscreteState]
@@ -242,7 +242,7 @@ class AlgorithmBase(odatse.algorithm.AlgorithmBase):
     def local_update(
         self,
         beta: Union[float, np.ndarray],
-        extra_info_to_write: Union[List, Tuple] = None,
+        extra_info_to_write: Union[list, tuple] = None,
     ) -> None:
         """
         Perform one step of the Monte Carlo algorithm.
@@ -264,7 +264,7 @@ class AlgorithmBase(odatse.algorithm.AlgorithmBase):
         beta : Union[float, np.ndarray]
             Inverse temperature(s) controlling acceptance probability
             Can be single value or array (one per walker)
-        extra_info_to_write : Union[List, Tuple], optional
+        extra_info_to_write : Union[list, tuple], optional
             Additional data to log with results
 
         Notes

--- a/src/odatse/algorithm/pamc.py
+++ b/src/odatse/algorithm/pamc.py
@@ -6,7 +6,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
 # If a copy of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from typing import List, Dict, Union, Optional, TYPE_CHECKING
+from typing import Union, Optional, TYPE_CHECKING
 
 from io import open
 import copy
@@ -230,7 +230,7 @@ class Algorithm(odatse.algorithm.montecarlo.AlgorithmBase):
             if rem > 0:
                 self.numsteps_for_T[0 : (rem - 1)] += 1
         else:
-            ss: List[int] = []
+            ss: list[int] = []
             while numsteps > 0:
                 if numsteps > numsteps_annealing:
                     ss.append(numsteps_annealing)
@@ -421,7 +421,7 @@ class Algorithm(odatse.algorithm.montecarlo.AlgorithmBase):
             if v:
                 v.close()
 
-    def _gather_information(self, numT: int = None) -> Dict[str, np.ndarray]:
+    def _gather_information(self, numT: int = None) -> dict[str, np.ndarray]:
         """
         Collect and organize statistical information across all processes.
 
@@ -438,7 +438,7 @@ class Algorithm(odatse.algorithm.montecarlo.AlgorithmBase):
 
         Returns
         -------
-        Dict[str, np.ndarray]
+        dict[str, np.ndarray]
             Contains:
               - fxs: Energy values for all walkers
               - logweights: Log of importance weights
@@ -471,7 +471,7 @@ class Algorithm(odatse.algorithm.montecarlo.AlgorithmBase):
 
         return res
 
-    def _save_stats(self, info: Dict[str, np.ndarray]) -> None:
+    def _save_stats(self, info: dict[str, np.ndarray]) -> None:
         """
         Calculate and save statistical measures from the simulation.
 
@@ -487,7 +487,7 @@ class Algorithm(odatse.algorithm.montecarlo.AlgorithmBase):
 
         Parameters
         ----------
-        info : Dict[str, np.ndarray]
+        info : dict[str, np.ndarray]
             Dictionary containing the following keys:
               - fxs: Objective function of each walker over all processes.
               - logweights: Logarithm of weights.
@@ -711,7 +711,7 @@ class Algorithm(odatse.algorithm.montecarlo.AlgorithmBase):
             if fwrite:
                 fwrite.close()
 
-    def _post(self) -> Dict:
+    def _post(self) -> dict:
         """
         Post-processing after the algorithm execution.
 

--- a/src/odatse/algorithm/random_search.py
+++ b/src/odatse/algorithm/random_search.py
@@ -6,7 +6,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
 # If a copy of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from typing import List, Union, Dict, Optional
+from typing import Union, Optional
 
 from pathlib import Path
 from io import open
@@ -24,7 +24,7 @@ class Algorithm(MapperMPIAlgorithm):
     Algorithm class for data analysis of quantum beam diffraction experiments.
     Inherits from odatse.algorithm.mapper_mpi.Algorithm.
     """
-    mesh_list: List[Union[int, float]]
+    mesh_list: list[Union[int, float]]
 
     def __init__(self, info: odatse.Info,
                  runner: Optional[odatse.Runner] = None,

--- a/src/odatse/algorithm/state.py
+++ b/src/odatse/algorithm/state.py
@@ -6,8 +6,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
 # If a copy of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import typing
-from typing import TextIO, Union, List, Tuple
+from typing import TextIO, Union
 import copy
 import time
 from pathlib import Path

--- a/src/odatse/domain/_domain.py
+++ b/src/odatse/domain/_domain.py
@@ -6,8 +6,6 @@
 # This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
 # If a copy of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from typing import List, Dict, Union, Any
-
 from pathlib import Path
 import numpy as np
 

--- a/src/odatse/domain/meshgrid.py
+++ b/src/odatse/domain/meshgrid.py
@@ -6,7 +6,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
 # If a copy of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from typing import List, Dict, Union, Any
+from typing import Union, Any
 
 from pathlib import Path
 import numpy as np
@@ -19,15 +19,15 @@ class MeshGrid(DomainBase):
     MeshGrid class for handling grid data for quantum beam diffraction experiments.
     """
 
-    grid: List[List[Union[int, float]]] = []
-    grid_local: List[List[Union[int, float]]] = []
+    grid: list[list[Union[int, float]]] = []
+    grid_local: list[list[Union[int, float]]] = []
     candicates: int
 
     def __init__(
         self,
         info: odatse.Info = None,
         *,
-        param: Dict[str, Any] = None,
+        param: dict[str, Any] = None,
         mesh: bool = True,
         rng: np.random.RandomState = None,
     ):

--- a/src/odatse/domain/region.py
+++ b/src/odatse/domain/region.py
@@ -6,7 +6,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
 # If a copy of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from typing import List, Dict, Union, Any
+from typing import Union, Any
 
 from pathlib import Path
 import numpy as np
@@ -35,7 +35,7 @@ class Region(DomainBase):
     unit_list: np.array
     initial_list: np.array
 
-    def __init__(self, info: odatse.Info = None, *, param: Dict[str, Any] = None):
+    def __init__(self, info: odatse.Info = None, *, param: dict[str, Any] = None):
         """
         Initialize the Region object.
 

--- a/src/odatse/solver/_solver.py
+++ b/src/odatse/solver/_solver.py
@@ -16,7 +16,6 @@ import odatse.mpi
 
 # type hints
 from pathlib import Path
-from typing import Dict, List, Tuple
 
 
 class SolverBase(object, metaclass=ABCMeta):
@@ -30,7 +29,7 @@ class SolverBase(object, metaclass=ABCMeta):
     work_dir: Path
     _name: str
     dimension: int
-    timer: Dict[str, Dict]
+    timer: dict[str, dict]
 
     @abstractmethod
     def __init__(self, info: odatse.Info) -> None:
@@ -66,7 +65,7 @@ class SolverBase(object, metaclass=ABCMeta):
         return self._name
 
     @abstractmethod
-    def evaluate(self, x: np.ndarray, arg: Tuple = (), nprocs: int = 1, nthreads: int = 1) -> None:
+    def evaluate(self, x: np.ndarray, arg: tuple = (), nprocs: int = 1, nthreads: int = 1) -> float:
         """
         Evaluate the solver with the given parameters.
 
@@ -74,7 +73,7 @@ class SolverBase(object, metaclass=ABCMeta):
         ----------
         x : np.ndarray
             Input data array.
-        arg : Tuple, optional
+        arg : tuple, optional
             Additional arguments for evaluation. Defaults to ().
         nprocs : nt, optional
             Number of processes to use. Defaults to 1.

--- a/src/odatse/solver/function.py
+++ b/src/odatse/solver/function.py
@@ -13,7 +13,7 @@ import time
 
 # type hints
 from pathlib import Path
-from typing import Callable, Optional, Dict, Tuple
+from typing import Callable, Optional
 
 
 class Solver(odatse.solver.SolverBase):
@@ -40,7 +40,7 @@ class Solver(odatse.solver.SolverBase):
         # for debug purpose
         self.delay = info.solver.get("delay", 0.0)
 
-    def evaluate(self, x: np.ndarray, args: Tuple = (), nprocs: int = 1, nthreads: int = 1) -> float:
+    def evaluate(self, x: np.ndarray, args: tuple = (), nprocs: int = 1, nthreads: int = 1) -> float:
         """
         Evaluate the function with given parameters.
 
@@ -48,7 +48,7 @@ class Solver(odatse.solver.SolverBase):
         ----------
         x : np.ndarray
             Input array for the function.
-        args : Tuple, optional
+        args : tuple, optional
             Additional arguments for the function.
         nprocs : int, optional
             Number of processes to use.

--- a/src/odatse/util/graph.py
+++ b/src/odatse/util/graph.py
@@ -7,19 +7,18 @@
 # If a copy of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 
-from typing import List
 
 import collections
 import numpy as np
 
 
-def is_connected(nnlist: List[List[int]]) -> bool:
+def is_connected(nnlist: list[list[int]]) -> bool:
     """
     Check if the graph represented by the neighbor list is connected.
 
     Parameters
     ----------
-    nnlist : List[List[int]]
+    nnlist : list[list[int]]
         A list of lists where each sublist represents the neighbors of a node.
 
     Returns
@@ -42,13 +41,13 @@ def is_connected(nnlist: List[List[int]]) -> bool:
     return nvisited == nnodes
 
 
-def is_bidirectional(nnlist: List[List[int]]) -> bool:
+def is_bidirectional(nnlist: list[list[int]]) -> bool:
     """
     Check if the graph represented by the neighbor list is bidirectional.
 
     Parameters
     ----------
-    nnlist : List[List[int]]
+    nnlist : list[list[int]]
         A list of lists where each sublist represents the neighbors of a node.
 
     Returns

--- a/src/odatse/util/logger.py
+++ b/src/odatse/util/logger.py
@@ -12,7 +12,7 @@ import numpy as np
 
 # type hints
 from pathlib import Path
-from typing import List, Dict, Any, Optional
+from typing import Any, Optional
 
 # Parameters
 # ----------
@@ -29,7 +29,7 @@ class Logger:
 
     logfile: Path
     buffer_size: int
-    buffer: List[str]
+    buffer: list[str]
     num_calls: int
     time_start: float
     time_previous: float
@@ -42,7 +42,7 @@ class Logger:
                  filename: str = "runner.log",
                  write_input: bool = False,
                  write_result: bool = False,
-                 params: Optional[Dict[str,Any]] = None,
+                 params: Optional[dict[str, Any]] = None,
                  **rest) -> None:
         """
         Initialize the Logger.
@@ -59,7 +59,7 @@ class Logger:
             Flag to indicate if input should be logged.
         write_result : bool
             Flag to indicate if result should be logged.
-        params : Dict[str,Any]], optional
+        params : dict[str, Any], optional
             Additional parameters for logging.
         **rest
             Additional keyword arguments.

--- a/src/odatse/util/neighborlist.py
+++ b/src/odatse/util/neighborlist.py
@@ -7,7 +7,6 @@
 # If a copy of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import typing
-from typing import List, Set
 from os import PathLike
 
 import sys
@@ -35,7 +34,7 @@ class Cells:
     
     Attributes
     ----------
-    cells : List[Set[int]]
+    cells : list[set[int]]
         List of sets, where each set contains indices of points in that cell.
     dimension : int
         Number of spatial dimensions.
@@ -61,7 +60,7 @@ class Cells:
     >>> cells.cells[cell_index].add(point_index)
     """
 
-    cells: List[Set[int]]
+    cells: list[set[int]]
     dimension: int
     mins: np.ndarray
     maxs: np.ndarray
@@ -246,7 +245,7 @@ class Cells:
             return True
         return False
 
-    def neighborcells(self, index: int) -> List[int]:
+    def neighborcells(self, index: int) -> list[int]:
         """
         Get the indices of neighboring cells, including the cell itself.
         
@@ -260,7 +259,7 @@ class Cells:
             
         Returns
         -------
-        List[int]
+        list[int]
             The indices of the neighboring cells (including the cell itself).
             
         Examples
@@ -270,7 +269,7 @@ class Cells:
         >>> len(neighbors)  # 3x3 neighborhood in 2D
         9
         """
-        neighbors: List[int] = []
+        neighbors: list[int] = []
         center_coord = self.cellindex2cellcoord(index)
         for diff in itertools.product([-1, 0, 1], repeat=self.dimension):
             other_coord = center_coord + np.array(diff)
@@ -286,7 +285,7 @@ def make_neighbor_list_cell(
     allow_selfloop: bool,
     show_progress: bool,
     comm: mpi.Comm = None,
-) -> List[List[int]]:
+) -> list[list[int]]:
     """
     Create a neighbor list using cell-based spatial partitioning.
     
@@ -309,7 +308,7 @@ def make_neighbor_list_cell(
         
     Returns
     -------
-    List[List[int]]
+    list[list[int]]
         A list of lists, where each inner list contains the indices of
         neighboring points for a given point.
         
@@ -340,7 +339,7 @@ def make_neighbor_list_cell(
 
     points = np.array_split(range(npoints), mpisize)[mpirank]
     npoints_local = len(points)
-    nnlist: List[List[int]] = [[] for _ in range(npoints_local)]
+    nnlist: list[list[int]] = [[] for _ in range(npoints_local)]
 
     if mpirank == 0 and show_progress and has_tqdm:
         desc = "rank 0" if mpisize > 1 else None
@@ -372,7 +371,7 @@ def make_neighbor_list_naive(
     allow_selfloop: bool,
     show_progress: bool,
     comm: mpi.Comm = None,
-) -> List[List[int]]:
+) -> list[list[int]]:
     """
     Create a neighbor list using a naive all-pairs approach.
     
@@ -396,7 +395,7 @@ def make_neighbor_list_naive(
         
     Returns
     -------
-    List[List[int]]
+    list[list[int]]
         A list of lists, where each inner list contains the indices of
         neighboring points for a given point.
         
@@ -419,7 +418,7 @@ def make_neighbor_list_naive(
     npoints = X.shape[0]
     points = np.array_split(range(npoints), mpisize)[mpirank]
     npoints_local = len(points)
-    nnlist: List[List[int]] = [[] for _ in range(npoints_local)]
+    nnlist: list[list[int]] = [[] for _ in range(npoints_local)]
 
     if mpirank == 0 and show_progress and has_tqdm:
         desc = "rank 0" if mpisize > 1 else None
@@ -450,7 +449,7 @@ def make_neighbor_list(
     check_allpairs: bool = False,
     show_progress: bool = False,
     comm: mpi.Comm = None,
-) -> List[List[int]]:
+) -> list[list[int]]:
     """
     Create a neighbor list for given points.
     
@@ -476,7 +475,7 @@ def make_neighbor_list(
         
     Returns
     -------
-    List[List[int]]
+    list[list[int]]
         A list of lists, where each inner list contains the indices of
         neighboring points for a given point.
         
@@ -510,7 +509,7 @@ def make_neighbor_list(
         )
 
 
-def load_neighbor_list(filename: PathLike, nnodes: int = None) -> List[List[int]]:
+def load_neighbor_list(filename: PathLike, nnodes: int = None) -> list[list[int]]:
     """
     Load a neighbor list from a file.
     
@@ -527,7 +526,7 @@ def load_neighbor_list(filename: PathLike, nnodes: int = None) -> List[List[int]
         
     Returns
     -------
-    List[List[int]]
+    list[list[int]]
         The neighbor list loaded from the file.
         
     Examples
@@ -549,7 +548,7 @@ def load_neighbor_list(filename: PathLike, nnodes: int = None) -> List[List[int]
                     continue
                 nnodes += 1
 
-    neighbor_list: List[List[int]] = [[] for _ in range(nnodes)]
+    neighbor_list: list[list[int]] = [[] for _ in range(nnodes)]
     with open(filename) as f:
         for line in f:
             line = line.strip().split("#")[0]
@@ -564,7 +563,7 @@ def load_neighbor_list(filename: PathLike, nnodes: int = None) -> List[List[int]
 
 def write_neighbor_list(
     filename: str,
-    nnlist: List[List[int]],
+    nnlist: list[list[int]],
     radius: float = None,
     unit: np.ndarray = None,
 ) -> None:
@@ -579,7 +578,7 @@ def write_neighbor_list(
     ----------
     filename : str
         The path to the output file.
-    nnlist : List[List[int]]
+    nnlist : list[list[int]]
         The neighbor list to write.
     radius : float, optional
         The neighborhood radius, written as a comment in the file, by default None.

--- a/src/odatse/util/read_matrix.py
+++ b/src/odatse/util/read_matrix.py
@@ -6,18 +6,18 @@
 # This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
 # If a copy of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from typing import Union, List
+from typing import Union
 
 import numpy as np
 
 
-def read_vector(inp: Union[str, List[float]]) -> np.ndarray:
+def read_vector(inp: Union[str, list[float]]) -> np.ndarray:
     """
     Converts an input string or list of floats into a numpy array vector.
 
     Parameters
     ----------
-    inp : Union[str, List[float]]
+    inp : Union[str, list[float]]
         Input data, either as a space-separated string of numbers or a list of floats.
 
     Returns
@@ -40,13 +40,13 @@ def read_vector(inp: Union[str, List[float]]) -> np.ndarray:
         raise RuntimeError(msg)
     return v
 
-def read_matrix(inp: Union[str, List[List[float]]]) -> np.ndarray:
+def read_matrix(inp: Union[str, list[list[float]]]) -> np.ndarray:
     """
     Converts an input string or list of lists of floats into a numpy array matrix.
 
     Parameters
     ----------
-    inp : Union[str, List[List[float]]]
+    inp : Union[str, list[list[float]]]
         Input data, either as a string with rows of space-separated numbers or a list of lists of floats.
 
     Returns
@@ -60,7 +60,7 @@ def read_matrix(inp: Union[str, List[List[float]]]) -> np.ndarray:
         If the input is not a matrix.
     """
     if isinstance(inp, str):
-        Alist: List[List[float]] = []
+        Alist: list[list[float]] = []
         for line in inp.split("\n"):
             if not line.strip():  # empty
                 continue

--- a/src/odatse/util/read_ts.py
+++ b/src/odatse/util/read_ts.py
@@ -6,12 +6,11 @@
 # This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
 # If a copy of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import typing
-from typing import TextIO, Union, List, Tuple
+from typing import TextIO, Union
 
 import numpy as np
 
-def read_Ts(info: dict, numT: int = None) -> Tuple[bool, np.ndarray]:
+def read_Ts(info: dict, numT: int = None) -> tuple[bool, np.ndarray]:
     """
     Read temperature or inverse-temperature values from the provided info dictionary.
 

--- a/src/odatse/util/resampling.py
+++ b/src/odatse/util/resampling.py
@@ -7,7 +7,7 @@
 # If a copy of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import typing
-from typing import Union, List, Iterable
+from typing import Union, Iterable, overload
 
 import abc
 
@@ -30,7 +30,7 @@ class BinarySearch(Resampler):
     """
     A resampler that uses binary search to sample based on given weights.
     """
-    weights_accumulated: List[float]
+    weights_accumulated: list[float]
     wmax: float
 
     def __init__(self, weights: Iterable):
@@ -56,7 +56,7 @@ class BinarySearch(Resampler):
         self.weights_accumulated = list(itertools.accumulate(weights))
         self.wmax = self.weights_accumulated[-1]
 
-    @typing.overload
+    @overload
     def sample(self, rs: np.random.RandomState) -> int:
         """
         Sample a single index based on the weights.
@@ -73,7 +73,7 @@ class BinarySearch(Resampler):
         """
         ...
 
-    @typing.overload
+    @overload
     def sample(self, rs: np.random.RandomState, size) -> np.ndarray:
         """
         Sample multiple indices based on the weights.
@@ -177,7 +177,7 @@ class WalkerTable(Resampler):
         self.ptable += mean
         self.ptable *= 1.0 / mean
 
-    @typing.overload
+    @overload
     def sample(self, rs: np.random.RandomState) -> int:
         """
         Sample a single index based on the weights.
@@ -194,7 +194,7 @@ class WalkerTable(Resampler):
         """
         ...
 
-    @typing.overload
+    @overload
     def sample(self, rs: np.random.RandomState, size) -> np.ndarray:
         """
         Sample multiple indices based on the weights.

--- a/src/odatse/util/separateT.py
+++ b/src/odatse/util/separateT.py
@@ -6,7 +6,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
 # If a copy of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from typing import Dict, List, Optional
+from typing import Optional
 import pathlib
 from os import PathLike
 from collections import namedtuple
@@ -58,7 +58,7 @@ def separateT(
     T2rank = {}
     results = []
     for rank, Ts_local in enumerate(np.array_split(Ts, mpisize)):
-        d: Dict[str, List[Entry]] = {}
+        d: dict[str, list[Entry]] = {}
         for T in Ts_local:
             T2rank[str(T)] = rank
             d[str(T)] = []

--- a/src/odatse/util/toml.py
+++ b/src/odatse/util/toml.py
@@ -6,7 +6,8 @@
 # This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
 # If a copy of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from typing import MutableMapping, Any
+from collections.abc import MutableMapping
+from typing import Any
 
 from ..mpi import rank
 


### PR DESCRIPTION
The current ODAT-SE requires Python 3.9 or later, so this PR removes deprecated classes in Python3.9, e.g., `typing.List`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly annotation-only refactors, but it touches core interfaces (`SolverBase.evaluate`) and MPI execution paths, so mismatched downstream implementations or unexpected `None` communicators could surface at runtime.
> 
> **Overview**
> Updates the codebase to rely on Python 3.9+ built-in generics, replacing deprecated `typing.List`/`Dict`/`Tuple`/`MutableMapping` usage with `list[...]`/`dict[...]`/`tuple[...]` and `collections.abc.MutableMapping` across algorithms, domains, utilities, and docs.
> 
> Tightens a few type/contract edges while doing so: `SolverBase.evaluate` is now typed to return `float`, and MPI-dependent paths in `exchange` add `assert self.mpicomm is not None` guards before calling MPI collectives/barriers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 13608a9f11d540e154da3bd5606b2c77b92ba7be. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->