### PR TITLE
Add argv parameter to initialize() to avoid sys.argv mutation

### DIFF
--- a/sample/gpr/gpr.py
+++ b/sample/gpr/gpr.py
@@ -136,8 +136,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
     
     # Initialize ODAT-SE to get output directory
-    sys.argv = ["script.py", args.input, "--init"]
-    info, run_mode = odatse.initialize()
+    info, run_mode = odatse.initialize([args.input, "--init"])
     output_dir = info.base.get("output_dir", "./output")
     
     # Create output directory if it doesn't exist

--- a/sample/linreg_with_noise/linreg_with_noise.py
+++ b/sample/linreg_with_noise/linreg_with_noise.py
@@ -142,10 +142,8 @@ if __name__ == "__main__":
     # Step 1: Run ODAT-SE
     print("\nStep 1: Running ODAT-SE linear regression...")
 
-    sys.argv = ["script.py", args.input, "--init"]
-
     # Initialize ODAT-SE to get output directory
-    info, run_mode = odatse.initialize()
+    info, run_mode = odatse.initialize([args.input, "--init"])
     output_dir = info.base.get("output_dir", "./output")
 
     # Create output directory if it doesn't exist

--- a/src/odatse/_initialize.py
+++ b/src/odatse/_initialize.py
@@ -6,11 +6,20 @@
 # This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
 # If a copy of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+from typing import Optional, Sequence
+
 import odatse
 
-def initialize():
+def initialize(argv: Optional[Sequence[str]] = None):
     """
     Initialize for main function by parsing commandline arguments and loading input files
+
+    Parameters
+    ----------
+    argv : list of str, optional
+        Argument list to parse. If None (default), sys.argv[1:] is used.
+        Pass an explicit list to avoid modifying sys.argv when embedding
+        odatse in a larger script that has its own argument parser.
 
     Returns
     -------
@@ -35,7 +44,7 @@ def initialize():
 
     parser.add_argument("--reset_rand", action="store_true", default=False, help="new random number series in resume or continue mode")
 
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
 
     if args.init is True:

--- a/src/odatse/_main.py
+++ b/src/odatse/_main.py
@@ -6,17 +6,19 @@
 # This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
 # If a copy of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+from typing import Optional, Sequence
+
 import sys
 import odatse
 
-def main():
+def main(argv: Optional[Sequence[str]] = None):
     """
     Main function to run the data-analysis software for quantum beam diffraction experiments
     on 2D material structures. It parses command-line arguments, loads the input file,
     selects the appropriate algorithm and solver, and executes the analysis.
     """
 
-    info, run_mode = odatse.initialize()
+    info, run_mode = odatse.initialize(argv)
 
     alg_module = odatse.algorithm.choose_algorithm(info.algorithm["name"])
 


### PR DESCRIPTION
## Summary

Add an optional `argv` parameter to `odatse.initialize()` so callers can
pass an explicit argument list instead of relying on `sys.argv`.

## Changes

- `src/odatse/_initialize.py`: Accept `argv: Optional[Sequence[str]] = None`
  and pass it to `parser.parse_args()`. When `None`, the existing behavior
  (`sys.argv[1:]`) is preserved.
- `sample/gpr/gpr.py`, `sample/linreg_with_noise/linreg_with_noise.py`:
  Remove the `sys.argv = [...]` workaround and call
  `odatse.initialize([args.input, "--init"])` directly.

## Motivation

Scripts that embed ODAT-SE alongside their own argument parser had to
overwrite `sys.argv` as a workaround. The new parameter provides a clean
API for this use case without side effects.

## Compatibility

No breaking change — the default value keeps existing call sites working
without modification.