### PR TITLE
Refactor checkpoint save/restore using declarative _checkpoint_attrs

### DIFF
--- a/src/odatse/algorithm/_algorithm.py
+++ b/src/odatse/algorithm/_algorithm.py
@@ -57,6 +57,51 @@ class AlgorithmBase(metaclass=ABCMeta):
     status: AlgorithmStatus = AlgorithmStatus.INIT
     mode: Optional[str] = None
 
+    # Fields saved/restored at every checkpoint for this class.
+    # Each subclass declares only its own fields; ``__getstate__`` collects
+    # them all by walking the MRO.
+    _checkpoint_attrs: list[str] = []
+
+    def __getstate__(self) -> dict:
+        """Return a checkpoint snapshot of the full algorithm state.
+
+        Saves the MPI configuration, RNG state, timer, and ``info``, then
+        appends every field declared in ``_checkpoint_attrs`` by this class
+        and all its subclasses (collected via MRO traversal).  Subclasses
+        need only declare their own ``_checkpoint_attrs``; no override is
+        needed unless extra non-attribute data must be saved (e.g. a global
+        RNG or an external policy object).
+        """
+        state: dict = {
+            "mpisize": self.mpisize,
+            "mpirank": self.mpirank,
+            "rng": self.rng.get_state(),
+            "timer": self.timer,
+            "info": self.info,
+        }
+        for cls in reversed(type(self).__mro__):
+            for attr in cls.__dict__.get("_checkpoint_attrs", []):
+                state[attr] = getattr(self, attr)
+        return state
+
+    def _apply_state(self, data: dict) -> None:
+        """Restore the base algorithm state from a checkpoint snapshot.
+
+        Validates the MPI configuration, restores the timer, and checks
+        that algorithm parameters are consistent.  Subclasses should call
+        ``super()._apply_state(data)`` and then handle their own fields
+        (RNG restore, subclass-specific ``_checkpoint_attrs``, etc.).
+
+        Parameters
+        ----------
+        data : dict
+            Snapshot previously produced by ``__getstate__``.
+        """
+        assert self.mpisize == data["mpisize"]
+        assert self.mpirank == data["mpirank"]
+        self.timer = data["timer"]
+        self._check_parameters(data["info"])
+
     @abstractmethod
     def __init__(
             self,

--- a/src/odatse/algorithm/_iterator.py
+++ b/src/odatse/algorithm/_iterator.py
@@ -11,6 +11,9 @@ from odatse import mpi
 
 
 class IteratorBase(object):
+    # Fields saved/restored at checkpoint; subclasses declare their own list.
+    _checkpoint_attrs: list[str] = []
+
     def __init__(self, mpicomm):
         if mpicomm is None:
             self.mpicomm = mpi.comm()
@@ -23,6 +26,15 @@ class IteratorBase(object):
 
         self._index_start = 0
         self._index_end = 0
+
+    def _save_state(self) -> dict:
+        """Return a snapshot of the iterator position as a plain dict."""
+        return {attr: getattr(self, attr) for attr in type(self)._checkpoint_attrs}
+
+    def _restore_state(self, d: dict) -> None:
+        """Restore the iterator position from a snapshot dict."""
+        for attr in type(self)._checkpoint_attrs:
+            setattr(self, attr, d[attr])
 
     def __iter__(self):
         return self
@@ -42,9 +54,11 @@ class IteratorBase(object):
 
 
 class MeshIterator(IteratorBase):
+    _checkpoint_attrs: list[str] = ["_i"]
+
     def __init__(self, xmin, xmax, xnum, mpicomm=None):
         super().__init__(mpicomm)
-        
+
         self._xlist = [np.linspace(l, h, n) for l, h, n in zip(xmin, xmax, xnum)]
         self._num = np.array(xnum)
         #self._stride = np.cumprod([1]+xnum[::-1])[::-1][1:]  # row major
@@ -62,19 +76,13 @@ class MeshIterator(IteratorBase):
         self._i += 1
         return tag, coord
 
-    def _save_state(self):
-        return {
-            "index": self._i,
-        }
-
-    def _restore_state(self, d):
-        self._i = d["index"]
-
 
 class ListIterator(IteratorBase):
+    _checkpoint_attrs: list[str] = ["_i", "_data"]
+
     def __init__(self, data, mpicomm=None):
         # input: rank 0 has all data
-        # split data and distrubute to other ranks
+        # split data and distribute to other ranks
         super().__init__(mpicomm)
 
         self._data = self._setup(data)
@@ -103,17 +111,10 @@ class ListIterator(IteratorBase):
             data = self.mpicomm.scatter(data_block, root=0)
         return data
 
-    def _save_state(self):
-        return {
-            "index": self._i,
-            "data": self._data,
-        }
-
-    def _restore_state(self, d):
-        self._i = d["index"]
-        self._data = d["data"]
 
 class DistributedListIterator(IteratorBase):
+    _checkpoint_attrs: list[str] = ["_i", "_data"]
+
     def __init__(self, data, mpicomm=None):
         # all ranks have their own chunk of data
         super().__init__(mpicomm)
@@ -131,17 +132,10 @@ class DistributedListIterator(IteratorBase):
         self._i += 1
         return data[0], data[1:]
 
-    def _save_state(self):
-        return {
-            "index": self._i,
-            "data": self._data,
-        }
-
-    def _restore_state(self, d):
-        self._i = d["index"]
-        self._data = d["data"]
 
 class RandomIterator(IteratorBase):
+    _checkpoint_attrs: list[str] = ["_i"]
+
     def __init__(self, xmin, xmax, count, rng, mpicomm=None):
         super().__init__(mpicomm)
 
@@ -161,13 +155,12 @@ class RandomIterator(IteratorBase):
         self._i += 1
         return tag, coord
 
-    def _save_state(self):
-        return {
-            "index": self._i,
-            "rng_state": self._rng.get_state(),
-        }
+    def _save_state(self) -> dict:
+        state = super()._save_state()
+        state["rng_state"] = self._rng.get_state()
+        return state
 
-    def _restore_state(self, d):
-        self._i = d["index"]
+    def _restore_state(self, d: dict) -> None:
+        super()._restore_state(d)
         self._rng = np.random.RandomState()
         self._rng.set_state(d["rng_state"])

--- a/src/odatse/algorithm/bayes.py
+++ b/src/odatse/algorithm/bayes.py
@@ -269,69 +269,62 @@ class Algorithm(odatse.algorithm.AlgorithmBase):
                 print(x, "=", y)
         return {"x": self.xopt, "fx": self.best_fx}
 
+    # Bayes-specific fields (simple getattr/setattr).
+    _checkpoint_attrs: list[str] = ["istep", "param_list", "fx_list"]
+
+    def __getstate__(self) -> dict:
+        """Return a checkpoint snapshot, extending the base with the global RNG."""
+        state = super().__getstate__()
+        state["random_number"] = np.random.get_state()
+        return state
+
     def _save_state(self, filename):
-        """
-        Saves the current state of the algorithm to a file.
-
-        Parameters
-        ----------
-        filename : str
-            The name of the file to save the state.
-        """
-        data = {
-            "mpisize": self.mpisize,
-            "mpirank": self.mpirank,
-            "rng": self.rng.get_state(),
-            "timer": self.timer,
-            "info": self.info,
-            "istep": self.istep,
-            "param_list": self.param_list,
-            "fx_list": self.fx_list,
-            "file_history": self.file_history,
-            "file_training": self.file_training,
-            "file_predictor": self.file_predictor,
-            "random_number": np.random.get_state(),
-        }
-        self._save_data(data, filename)
-
+        """Save the current state of the algorithm to a file."""
+        self._save_data(self.__getstate__(), filename)
         self.policy.save(file_history=Path(self.output_dir, self.file_history),
                          file_training=Path(self.output_dir, self.file_training),
                          file_predictor=Path(self.output_dir, self.file_predictor))
 
-    def _load_state(self, filename, mode="resume", restore_rng=True):
+    def _apply_state(self, data: dict, restore_rng: bool = True) -> None:
+        """Restore algorithm state from a checkpoint snapshot.
+
+        Delegates MPI validation, timer restore, and parameter check to the
+        base class, optionally restores both the instance RNG and the global
+        numpy RNG, applies the Bayes-specific fields, then loads the physbo
+        policy from the saved files.
+
+        Parameters
+        ----------
+        data : dict
+            Snapshot previously produced by ``__getstate__``.
+        restore_rng : bool
+            When *True* (default) both RNG states are restored from *data*.
         """
-        Loads the state of the algorithm from a file.
+        super()._apply_state(data)
+        if restore_rng:
+            self.rng = np.random.RandomState()
+            self.rng.set_state(data["rng"])
+            np.random.set_state(data["random_number"])
+        for attr in Algorithm._checkpoint_attrs:
+            setattr(self, attr, data[attr])
+        self.policy.load(file_history=Path(self.output_dir, self.file_history),
+                         file_training=Path(self.output_dir, self.file_training),
+                         file_predictor=Path(self.output_dir, self.file_predictor))
+
+    def _load_state(self, filename, mode="resume", restore_rng=True):
+        """Load the state of the algorithm from a file.
 
         Parameters
         ----------
         filename : str
-            The name of the file to load the state from.
+            Path to the checkpoint file.
         mode : str, optional
-            The mode to load the state (default is "resume").
+            Loading mode (currently unused; kept for API symmetry).
         restore_rng : bool, optional
-            Whether to restore the random number generator state (default is True).
+            Whether to restore RNG states, by default True.
         """
         data = self._load_data(filename)
         if not data:
             print("ERROR: Load status file failed")
             sys.exit(1)
-
-        assert self.mpisize == data["mpisize"]
-        assert self.mpirank == data["mpirank"]
-
-        if restore_rng:
-            self.rng = np.random.RandomState()
-            self.rng.set_state(data["rng"])
-            np.random.set_state(data["random_number"])
-        self.timer = data["timer"]
-
-        info = data["info"]
-        self._check_parameters(info)
-
-        self.istep = data["istep"]
-        self.param_list = data["param_list"]
-        self.fx_list = data["fx_list"]
-
-        self.policy.load(file_history=Path(self.output_dir, self.file_history),
-                         file_training=Path(self.output_dir, self.file_training),
-                         file_predictor=Path(self.output_dir, self.file_predictor))
+        self._apply_state(data, restore_rng=restore_rng)

--- a/src/odatse/algorithm/exchange.py
+++ b/src/odatse/algorithm/exchange.py
@@ -85,6 +85,9 @@ class Algorithm(odatse.algorithm.montecarlo.AlgorithmBase):
 
     exchange_direction: bool
 
+    # Exchange-specific fields appended to the MC base checkpoint.
+    _checkpoint_attrs: list[str] = ["nreplica", "Tindex", "rep2T", "T2rep", "exchange_direction"]
+
     def __init__(
         self,
         info: odatse.Info,
@@ -478,109 +481,45 @@ class Algorithm(odatse.algorithm.montecarlo.AlgorithmBase):
         }
 
     def _save_state(self, filename) -> None:
-        """
-        Save the current algorithm state to a checkpoint file.
+        """Save the current algorithm state to a checkpoint file."""
+        self._save_data(self.__getstate__(), filename)
 
-        Saves all necessary data to resume the simulation later, including:
-          - MPI configuration
-          - Random number generator state
-          - Timer information
-          - Current configurations and energies
-          - Best solutions found
-          - Replica exchange state information
+    def _apply_state(self, data: dict, restore_rng: bool = True) -> None:
+        """Restore algorithm state from a checkpoint snapshot.
+
+        Delegates MPI validation, RNG restore, and MC-layer fields to the
+        base class, validates the replica count, then applies exchange-specific
+        fields and propagates the restored RNG to the state space.
 
         Parameters
         ----------
-        filename : str
-            Path to the checkpoint file to write.
+        data : dict
+            Snapshot previously produced by ``__getstate__``.
+        restore_rng : bool
+            When *True* (default) the RNG state is restored from *data*;
+            when *False* a fresh RNG state is kept (``--reset_rand`` mode).
         """
-        data = {
-            #-- _algorithm
-            "mpisize": self.mpisize,
-            "mpirank": self.mpirank,
-            "rng": self.rng.get_state(),
-            "timer": self.timer,
-            "info": self.info,
-            #-- montecarlo
-            "x": self.state,
-            "fx": self.fx,
-            #"inode": self.inode,
-            "istep": self.istep,
-            "best_x": self.best_x,
-            "best_fx": self.best_fx,
-            "best_istep": self.best_istep,
-            "best_iwalker": self.best_iwalker,
-            "naccepted": self.naccepted,
-            "ntrial": self.ntrial,
-            #-- exchange
-            "nreplica": self.nreplica,
-            "Tindex": self.Tindex,
-            "rep2T": self.rep2T,
-            "T2rep": self.T2rep,
-            "exchange_direction": self.exchange_direction,
-        }
-        self._save_data(data, filename)
+        super()._apply_state(data, restore_rng)
+        assert self.nreplica == data["nreplica"]
+        for attr in Algorithm._checkpoint_attrs:
+            setattr(self, attr, data[attr])
+        self.statespace.rng = self.rng
 
     def _load_state(self, filename, mode="resume", restore_rng=True):
-        """
-        Load algorithm state from a checkpoint file.
-
-        Restores all necessary data to resume a previous simulation run.
+        """Load algorithm state from a checkpoint file.
 
         Parameters
         ----------
         filename : str
             Path to the checkpoint file to read.
         mode : str, optional
-            Loading mode - either "resume" or "continue", by default "resume".
+            Loading mode — ``"resume"`` or ``"continue"`` (currently unused
+            for REMC; kept for API symmetry with PAMC).
         restore_rng : bool, optional
-            Whether to restore the random number generator state, by default True.
-            Set to False to use a fresh RNG state.
-
-        Raises
-        ------
-        AssertionError
-            If loaded state doesn't match current MPI configuration.
+            Whether to restore the RNG state, by default True.
         """
         data = self._load_data(filename)
         if not data:
             print("ERROR: Load status file failed")
             sys.exit(1)
-
-        # -- _algorithm
-        assert self.mpisize == data["mpisize"]
-        assert self.mpirank == data["mpirank"]
-
-        if restore_rng:
-            self.rng = np.random.RandomState()
-            self.rng.set_state(data["rng"])
-        self.timer = data["timer"]
-
-        info = data["info"]
-        self._check_parameters(info)
-
-        # -- montecarlo
-        self.state = data["x"]
-        self.fx = data["fx"]
-        # self.inode = data["inode"]
-
-        self.istep = data["istep"]
-
-        self.best_x = data["best_x"]
-        self.best_fx = data["best_fx"]
-        self.best_istep = data["best_istep"]
-        self.best_iwalker = data["best_iwalker"]
-
-        self.naccepted = data["naccepted"]
-        self.ntrial = data["ntrial"]
-
-        # -- exchange
-        assert self.nreplica == data["nreplica"]
-
-        self.Tindex = data["Tindex"]
-        self.rep2T = data["rep2T"]
-        self.T2rep = data["T2rep"]
-        self.exchange_direction = data["exchange_direction"]
-
-        # -- restore rng state in statespace
-        self.statespace.rng = self.rng
+        self._apply_state(data, restore_rng=restore_rng)

--- a/src/odatse/algorithm/mapper_mpi_base.py
+++ b/src/odatse/algorithm/mapper_mpi_base.py
@@ -201,52 +201,44 @@ class Algorithm(AlgorithmBase):
 
         return {}
 
-    def _save_state(self, filename) -> None:
-        """
-        Save the current state of the algorithm to a file.
+    # Mapper-specific fields (simple getattr/setattr).
+    _checkpoint_attrs: list[str] = ["results", "opt_fx", "opt_mesh"]
 
-        Parameters
-        ----------
-        filename
-            The name of the file to save the state to.
-        """
-        data = {
-            "mpisize": self.mpisize,
-            "mpirank": self.mpirank,
-            "timer": self.timer,
-            "info": self.info,
-            "results": self.results,
-            "opt_fx": self.opt_fx,
-            "opt_mesh": self.opt_mesh,
-        }
+    def _save_state(self, filename) -> None:
+        """Save the current state of the algorithm to a file."""
+        data = self.__getstate__()
         data.update(self._iter._save_state())
         self._save_data(data, filename)
 
-    def _load_state(self, filename, restore_rng=True):
+    def _apply_state(self, data: dict) -> None:
+        """Restore algorithm state from a checkpoint snapshot.
+
+        Delegates MPI validation, timer restore, and parameter check to the
+        base class, applies the mapper-specific fields, then restores the
+        iterator position.
+
+        Parameters
+        ----------
+        data : dict
+            Snapshot previously produced by ``_save_state``.
         """
-        Load the state of the algorithm from a file.
+        super()._apply_state(data)
+        for attr in Algorithm._checkpoint_attrs:
+            setattr(self, attr, data[attr])
+        self._iter._restore_state(data)
+
+    def _load_state(self, filename, restore_rng=True) -> None:
+        """Load the state of the algorithm from a file.
 
         Parameters
         ----------
         filename
-            The name of the file to load the state from.
+            Path to the checkpoint file.
         restore_rng : bool
-            Whether to restore the random number generator state.
+            Unused; kept for API consistency with other algorithms.
         """
         data = self._load_data(filename)
         if not data:
             print("ERROR: Load status file failed")
             sys.exit(1)
-
-        assert self.mpisize == data["mpisize"]
-        assert self.mpirank == data["mpirank"]
-
-        self.timer = data["timer"]
-
-        info = data["info"]
-        self._check_parameters(info)
-
-        self.results = data["results"]
-        self.opt_fx = data["opt_fx"]
-        self.opt_mesh = data["opt_mesh"]
-        self._iter._restore_state(data)
+        self._apply_state(data)

--- a/src/odatse/algorithm/montecarlo.py
+++ b/src/odatse/algorithm/montecarlo.py
@@ -100,6 +100,15 @@ class AlgorithmBase(odatse.algorithm.AlgorithmBase):
     ntrial: int
     naccepted: int
 
+    # Fields saved/restored at every checkpoint for all MC algorithms.
+    # Subclasses extend this by declaring their own ``_checkpoint_attrs``
+    # class variable; ``__getstate__`` collects them all via MRO traversal.
+    _checkpoint_attrs: list[str] = [
+        "state", "fx", "istep",
+        "best_x", "best_fx", "best_istep", "best_iwalker",
+        "naccepted", "ntrial",
+    ]
+
     def __init__(
         self,
         info: odatse.Info,
@@ -326,6 +335,30 @@ class AlgorithmBase(odatse.algorithm.AlgorithmBase):
     def _set_writer(self, fp_trial, fp_result):
         self.fp_trial = fp_trial
         self.fp_result = fp_result
+
+    def _apply_state(self, data: dict, restore_rng: bool = True) -> None:
+        """Restore algorithm state from a checkpoint snapshot.
+
+        Delegates MPI validation, timer restore, and parameter check to the
+        base class, optionally restores the RNG, then applies every field
+        listed in ``montecarlo.AlgorithmBase._checkpoint_attrs``.  Subclasses
+        that need additional fields should override this method, call
+        ``super()._apply_state()``, then handle their own fields.
+
+        Parameters
+        ----------
+        data : dict
+            Snapshot previously produced by ``__getstate__``.
+        restore_rng : bool
+            When *True* (default) the RNG state is restored from *data*;
+            when *False* a fresh RNG state is kept (``--reset_rand`` mode).
+        """
+        super()._apply_state(data)
+        if restore_rng:
+            self.rng = np.random.RandomState()
+            self.rng.set_state(data["rng"])
+        for attr in AlgorithmBase._checkpoint_attrs:
+            setattr(self, attr, data[attr])
 
     def _write_result(self, writer, extras=None):
         for iwalker in range(self.nwalkers):

--- a/src/odatse/algorithm/pamc.py
+++ b/src/odatse/algorithm/pamc.py
@@ -108,6 +108,19 @@ class Algorithm(odatse.algorithm.montecarlo.AlgorithmBase):
     Fmeans: np.ndarray
     Ferrs: np.ndarray
 
+    # PAMC-specific fields appended to the MC base checkpoint.
+    # Fields restored with slice assignment or special logic are still listed
+    # here so that ``__getstate__`` saves them; ``_apply_state`` handles them
+    # explicitly rather than via the generic setattr loop.
+    _checkpoint_attrs: list[str] = [
+        "betas", "nwalkers", "input_as_beta", "numsteps_for_T",
+        "Tindex", "index_from_reset",
+        "logZ", "logZs", "logweights",
+        "Fmeans", "Ferrs", "nreplicas", "populations",
+        "family_lo", "family_hi", "walker_ancestors", "fx_from_reset",
+        "naccepted_from_reset", "acceptance_ratio", "pr_list",
+    ]
+
     def __init__(
         self,
         info: odatse.Info,
@@ -799,137 +812,55 @@ class Algorithm(odatse.algorithm.montecarlo.AlgorithmBase):
         }
 
     def _save_state(self, filename) -> None:
-        """
-        Save the current state of the algorithm to a file.
+        """Save the current state of the algorithm to a file."""
+        self._save_data(self.__getstate__(), filename)
+
+    def _apply_state(self, data: dict, restore_rng: bool = True, mode: str = "resume") -> None:
+        """Restore algorithm state from a checkpoint snapshot.
+
+        Delegates MPI validation, RNG restore, and MC-layer fields to the
+        base class, then handles PAMC-specific fields explicitly.  Simple
+        scalar fields are set directly; array fields that may be shorter than
+        the current schedule (``logZs``, ``Fmeans``, etc.) are written with
+        slice assignment after re-initialisation.
 
         Parameters
         ----------
-        filename : str
-            The name of the file where the state will be saved.
+        data : dict
+            Snapshot previously produced by ``__getstate__``.
+        restore_rng : bool
+            When *True* (default) the RNG state is restored from *data*;
+            when *False* a fresh RNG state is kept (``--reset_rand`` mode).
+        mode : str
+            ``"resume"`` — validate that the temperature schedule is identical
+            to the one stored in *data*.
+            ``"continue"`` — concatenate the stored schedule with the new one
+            (the stored last beta must equal the new first beta).
         """
-        data = {
-            #-- _algorithm
-            "mpisize": self.mpisize,
-            "mpirank": self.mpirank,
-            "rng": self.rng.get_state(),
-            "timer": self.timer,
-            "info": self.info,
-            #-- montecarlo
-            "x": self.state,
-            "fx": self.fx,
-            #"inode": self.inode,
-            "istep": self.istep,
-            "best_x": self.best_x,
-            "best_fx": self.best_fx,
-            "best_istep": self.best_istep,
-            "best_iwalker": self.best_iwalker,
-            "naccepted": self.naccepted,
-            "ntrial": self.ntrial,
-            #-- pamc
-            "betas": self.betas,
-            "nwalkers": self.nwalkers,
-            "input_as_beta": self.input_as_beta,
-            "numsteps_for_T": self.numsteps_for_T,
-            "Tindex": self.Tindex,
-            "index_from_reset": self.index_from_reset,
-            "logZ": self.logZ,
-            "logZs": self.logZs,
-            "logweights": self.logweights,
-            "Fmeans": self.Fmeans,
-            "Ferrs": self.Ferrs,
-            "nreplicas": self.nreplicas,
-            "populations": self.populations,
-            "family_lo": self.family_lo,
-            "family_hi": self.family_hi,
-            "walker_ancestors": self.walker_ancestors,
-            "fx_from_reset": self.fx_from_reset,
-            "naccepted_from_reset": self.naccepted_from_reset,
-            "acceptance_ratio": self.acceptance_ratio,
-            "pr_list": self.pr_list,
-        }
-        self._save_data(data, filename)
+        super()._apply_state(data, restore_rng)
 
-    def _load_state(self, filename, mode="resume", restore_rng=True):
-        """
-        Load the saved state of the algorithm from a file.
-
-        Parameters
-        ----------
-        filename : str
-            The name of the file from which the state will be loaded.
-        mode : str, optional
-            The mode in which to load the state. Can be "resume" or "continue", by default "resume".
-        restore_rng : bool, optional
-            Whether to restore the random number generator state, by default True.
-        """
-        data = self._load_data(filename)
-        if not data:
-            print("ERROR: Load status file failed")
-            sys.exit(1)
-
-        # -- _algorithm
-        assert self.mpisize == data["mpisize"]
-        assert self.mpirank == data["mpirank"]
-
-        if restore_rng:
-            self.rng = np.random.RandomState()
-            self.rng.set_state(data["rng"])
-        self.timer = data["timer"]
-
-        info = data["info"]
-        self._check_parameters(info)
-
-        # -- montecarlo
-        self.state = data["x"]
-        self.fx = data["fx"]
-        # self.inode = data["inode"]
-
-        self.istep = data["istep"]
-
-        self.best_x = data["best_x"]
-        self.best_fx = data["best_fx"]
-        self.best_istep = data["best_istep"]
-        self.best_iwalker = data["best_iwalker"]
-
-        self.naccepted = data["naccepted"]
-        self.ntrial = data["ntrial"]
-
-        # -- pamc
+        # -- simple scalar fields
         self.Tindex = data["Tindex"]
         self.index_from_reset = data["index_from_reset"]
         self.nwalkers = data["nwalkers"]
 
+        # -- temperature schedule (mode-dependent)
         if mode == "resume":
-            # check if scheduling is as stored
-            betas = data["betas"]
-            input_as_beta = data["input_as_beta"]
-            numsteps_for_T = data["numsteps_for_T"]
-
-            assert np.all(betas == self.betas)
-            assert input_as_beta == self.input_as_beta
-            assert np.all(numsteps_for_T == self.numsteps_for_T)
+            assert np.all(data["betas"] == self.betas)
+            assert data["input_as_beta"] == self.input_as_beta
+            assert np.all(data["numsteps_for_T"] == self.numsteps_for_T)
             assert self.Tindex < len(self.betas)
-
         elif mode == "continue":
-            # check if scheduling is continuous
-            betas = data["betas"]
-            input_as_beta = data["input_as_beta"]
-            numsteps_for_T = data["numsteps_for_T"]
-
-            assert input_as_beta == self.input_as_beta
-            if not betas[-1] == self.betas[0]:
-                print("ERROR: temperator is not continuous")
+            assert data["input_as_beta"] == self.input_as_beta
+            if not data["betas"][-1] == self.betas[0]:
+                print("ERROR: temperature is not continuous")
                 sys.exit(1)
-            self.betas = np.concatenate([betas, self.betas[1:]])
-            self.numsteps_for_T = np.concatenate([numsteps_for_T, self.numsteps_for_T[1:]])
+            self.betas = np.concatenate([data["betas"], self.betas[1:]])
+            self.numsteps_for_T = np.concatenate([data["numsteps_for_T"], self.numsteps_for_T[1:]])
 
-        else:
-            pass
-
+        # -- re-initialise length-numT arrays, then overwrite with saved data
         numT = len(self.betas)
-
         nreplicas = self.mpisize * self.nwalkers
-
         self.logZs = np.zeros(numT)
         self.Fmeans = np.zeros(numT)
         self.Ferrs = np.zeros(numT)
@@ -938,21 +869,36 @@ class Algorithm(odatse.algorithm.montecarlo.AlgorithmBase):
         self.pr_list = np.zeros(numT)
 
         self.logZ = data["logZ"]
-        self.logZs[0:len(data["logZs"])] = data["logZs"]
+        self.logZs[:len(data["logZs"])] = data["logZs"]
         self.logweights = data["logweights"]
-        self.Fmeans[0:len(data["Fmeans"])] = data["Fmeans"]
-        self.Ferrs[0:len(data["Ferrs"])] = data["Ferrs"]
-        self.nreplicas[0:len(data["nreplicas"])] = data["nreplicas"]
+        self.Fmeans[:len(data["Fmeans"])] = data["Fmeans"]
+        self.Ferrs[:len(data["Ferrs"])] = data["Ferrs"]
+        self.nreplicas[:len(data["nreplicas"])] = data["nreplicas"]
         self.populations = data["populations"].copy()
-
         self.family_lo = data["family_lo"]
         self.family_hi = data["family_hi"]
-
         self.fx_from_reset = data["fx_from_reset"]
         self.walker_ancestors = data["walker_ancestors"]
         self.naccepted_from_reset = data["naccepted_from_reset"]
-        self.acceptance_ratio[0:len(data["acceptance_ratio"])] = data["acceptance_ratio"]
-        self.pr_list[0:len(data["pr_list"])] = data["pr_list"]
+        self.acceptance_ratio[:len(data["acceptance_ratio"])] = data["acceptance_ratio"]
+        self.pr_list[:len(data["pr_list"])] = data["pr_list"]
 
-        # -- restore rng state in statespace
         self.statespace.rng = self.rng
+
+    def _load_state(self, filename, mode="resume", restore_rng=True):
+        """Load the saved state of the algorithm from a file.
+
+        Parameters
+        ----------
+        filename : str
+            Path to the checkpoint file to read.
+        mode : str, optional
+            ``"resume"`` or ``"continue"``, by default ``"resume"``.
+        restore_rng : bool, optional
+            Whether to restore the RNG state, by default True.
+        """
+        data = self._load_data(filename)
+        if not data:
+            print("ERROR: Load status file failed")
+            sys.exit(1)
+        self._apply_state(data, restore_rng=restore_rng, mode=mode)


### PR DESCRIPTION
## Summary
Refactor checkpoint save/restore across all algorithm classes by introducing
a declarative `_checkpoint_attrs` mechanism, eliminating repeated boilerplate
in every `_save_state` / `_load_state` implementation.
## Changes
### New protocol in `AlgorithmBase` (`_algorithm.py`)
- Add `_checkpoint_attrs: list[str] = []` class variable.
- Add `__getstate__`: walks the MRO and collects every field declared in
  `_checkpoint_attrs` from each level, together with the fixed base fields
  (MPI config, RNG, timer, info).
- Add `_apply_state`: validates MPI config, restores timer, and checks
  parameters. Subclasses call `super()._apply_state()` and handle their
  own fields on top.
### Iterator classes (`_iterator.py`)
- Move `_save_state` / `_restore_state` to `IteratorBase` as generic
  implementations driven by `_checkpoint_attrs`.
- Each concrete iterator (`MeshIterator`, `ListIterator`,
  `DistributedListIterator`, `RandomIterator`) replaces its hand-written
  methods with a single `_checkpoint_attrs` declaration.
  `RandomIterator` still overrides to handle the extra RNG state.
### Algorithm subclasses (`montecarlo.py`, `exchange.py`, `bayes.py`, `mapper_mpi_base.py`, `pamc.py`)
- Each class declares its own `_checkpoint_attrs`.
- `_save_state` is reduced to `self._save_data(self.__getstate__(), filename)`.
- `_load_state` is reduced to loading the file and calling `_apply_state`.
- `_apply_state` is layered via `super()` calls, handling RNG restore and
  subclass-specific fields at the appropriate level.
### Bug fixes
- Fix typo: `"temperator is not continuous"` → `"temperature is not
  continuous"` in `pamc.py`.
- Simplify slice assignments `[0:len(...)]` → `[:len(...)]` in `pamc.py`.
## Compatibility
No changes to checkpoint file format or public API.