### PR TITLE
Fix min_search scipy version gate and initial-point unit scaling

### DIFF
--- a/src/odatse/algorithm/min_search.py
+++ b/src/odatse/algorithm/min_search.py
@@ -15,6 +15,7 @@ from scipy.optimize import minimize
 
 import odatse
 import odatse.domain
+from odatse.util.version import parse_version
 
 if TYPE_CHECKING:
     from mpi4py import MPI
@@ -119,12 +120,11 @@ class Algorithm(odatse.algorithm.AlgorithmBase):
         iter_history = []
         fev_history = []
 
-        f0 = run.submit(self.initial_list, (0, 0))
+        # evaluate the initial point in solver units, as _f_calc does
+        f0 = run.submit(np.asarray(self.initial_list) / unit_list, (0, 0))
         iter_history.append([*self.initial_list, f0])
 
-        scipy_version = [int(s) for s in scipy.__version__.split('.')]
-
-        if scipy_version[0] >= 1 and scipy_version[1] >= 11:
+        if parse_version(scipy.__version__) >= (1, 11, 0):
             def _cb(intermediate_result):
                 """
                 Callback function for scipy.optimize.minimize.

--- a/src/odatse/util/version.py
+++ b/src/odatse/util/version.py
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: MPL-2.0
+#
+# ODAT-SE -- an open framework for data analysis
+# Copyright (C) 2020- The University of Tokyo
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+# If a copy of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import re
+
+
+def parse_version(version: str, ncomponents: int = 3) -> tuple:
+    """Parse a dotted version string into a tuple of integers.
+
+    Intended for numeric comparison of package versions, where a plain
+    string comparison is wrong (e.g. "1.10.0" < "1.2.0") and a bare
+    int() per component crashes on pre-release suffixes (e.g. "1.16.0rc1").
+
+    Only the leading digits of each component are used; a component
+    without leading digits and everything after it are ignored. The
+    result is zero-padded to ncomponents elements.
+
+    Parameters
+    ----------
+    version : str
+        Dotted version string, e.g. "1.16.0rc1".
+    ncomponents : int
+        Number of components in the returned tuple.
+
+    Returns
+    -------
+    tuple
+        Tuple of ncomponents integers, e.g. (1, 16, 0).
+    """
+    comps = []
+    for s in version.split(".")[:ncomponents]:
+        m = re.match(r"[0-9]+", s)
+        if m is None:
+            break
+        comps.append(int(m.group()))
+    comps.extend([0] * (ncomponents - len(comps)))
+    return tuple(comps)

--- a/tests/unit/test_min_search.py
+++ b/tests/unit/test_min_search.py
@@ -1,0 +1,72 @@
+import os
+import sys
+
+SOURCE_PATH = os.path.join(os.path.dirname(__file__), '../../src')
+# insert, not append: an installed odatse package must not shadow src/
+sys.path.insert(0, SOURCE_PATH)
+
+import numpy as np
+import pytest
+
+pytest.importorskip("scipy")
+
+import odatse
+import odatse.mpi
+import odatse.solver.function
+
+try:
+    odatse.mpi.setup()
+except RuntimeError:
+    pass  # already set up by another test module in this session
+
+import odatse.algorithm.min_search as min_search
+
+
+def _run_minsearch(workdir, unit_list, record):
+    def fn(x):
+        record.append(np.array(x, copy=True))
+        return float(np.sum(x * x))
+
+    inp = {
+        "base": {"dimension": 2, "output_dir": str(workdir / "output")},
+        "algorithm": {
+            "name": "minsearch",
+            "seed": 1,
+            "param": {
+                "min_list": [-5.0, -5.0],
+                "max_list": [5.0, 5.0],
+                "initial_list": [2.0, 2.0],
+                "unit_list": unit_list,
+            },
+            "minimize": {"maxiter": 3, "maxfev": 10},
+        },
+        "solver": {"name": "function"},
+        "runner": {},
+    }
+    info = odatse.Info(inp)
+    solver = odatse.solver.function.Solver(info)
+    solver.set_function(fn)
+    runner = odatse.Runner(solver, info)
+    alg = min_search.Algorithm(info, runner)
+    alg.main()
+
+
+def test_initial_evaluation_uses_unit_scaling(tmp_path, monkeypatch):
+    """The initial evaluation f0 must submit initial_list / unit_list,
+    consistently with every later evaluation through _f_calc."""
+    monkeypatch.chdir(tmp_path)
+    record = []
+    _run_minsearch(tmp_path, unit_list=[2.0, 2.0], record=record)
+    # initial point [2, 2] with unit_list [2, 2] must arrive at the solver
+    # as [1, 1]; the unfixed code submitted the unscaled [2, 2]
+    np.testing.assert_allclose(record[0], [1.0, 1.0])
+
+
+def test_run_with_prerelease_scipy_version(tmp_path, monkeypatch):
+    """The scipy version gate must not crash on pre-release versions
+    like '1.16.0rc1' (int('0rc1') raised ValueError)."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(min_search.scipy, "__version__", "1.16.0rc1")
+    record = []
+    _run_minsearch(tmp_path, unit_list=[1.0, 1.0], record=record)
+    assert len(record) > 0

--- a/tests/unit/test_version.py
+++ b/tests/unit/test_version.py
@@ -1,0 +1,42 @@
+import os
+import sys
+
+SOURCE_PATH = os.path.join(os.path.dirname(__file__), '../../src')
+# insert, not append: an installed odatse package must not shadow src/
+sys.path.insert(0, SOURCE_PATH)
+
+from odatse.util.version import parse_version
+
+
+def test_basic():
+    assert parse_version("1.11.4") == (1, 11, 4)
+    assert parse_version("2.0.0") == (2, 0, 0)
+
+
+def test_prerelease_suffix_ignored():
+    assert parse_version("1.16.0rc1") == (1, 16, 0)
+    assert parse_version("1.2rc1") == (1, 2, 0)
+    assert parse_version("1.26.0.dev0") == (1, 26, 0)
+
+
+def test_short_version_padded():
+    assert parse_version("1") == (1, 0, 0)
+    assert parse_version("1.2") == (1, 2, 0)
+
+
+def test_numeric_not_lexicographic():
+    # a plain string compare gives "1.10.0" < "1.2.0", which is wrong
+    assert parse_version("1.10.0") > parse_version("1.2.0")
+
+
+def test_scipy_gate_semantics():
+    # the min_search callback gate: modern branch for scipy >= 1.11
+    assert parse_version("1.11.0") >= (1, 11, 0)
+    assert parse_version("1.10.1") < (1, 11, 0)
+    # the old gate (major >= 1 and minor >= 11) was False for 2.0
+    assert parse_version("2.0.0") >= (1, 11, 0)
+
+
+def test_non_numeric_component():
+    assert parse_version("abc") == (0, 0, 0)
+    assert parse_version("1.x.4") == (1, 0, 0)


### PR DESCRIPTION
## Summary

Fixes the two pre-existing `min_search` bugs found during the review of #55:

- **Closes #56** — the scipy version gate `scipy_version[0] >= 1 and scipy_version[1] >= 11` mis-evaluates for scipy 2.x (falls back to the legacy callback, costing one redundant solver evaluation per Nelder-Mead iteration), and `[int(s) for s in __version__.split(".")]` crashes with `ValueError` on pre-release versions such as `1.16.0rc1`. Added `odatse.util.version.parse_version()` (numeric tuple comparison; leading digits per component, pre-release suffixes ignored, zero-padded) and gate on `parse_version(scipy.__version__) >= (1, 11, 0)`.
- **Closes #57** — the initial evaluation `f0 = run.submit(self.initial_list, (0, 0))` bypassed the `x / unit_list` scaling that every later evaluation applies via `_f_calc`, so with `unit_list != 1` the first row of `SimplexData.txt` was computed at a different physical point. Now submits `np.asarray(self.initial_list) / unit_list` (no in-place mutation).

## Tests

- `tests/unit/test_version.py` — `parse_version` unit tests (numeric vs lexicographic, pre-release suffixes, padding, the scipy gate semantics including the 2.0.0 case).
- `tests/unit/test_min_search.py` — end-to-end regressions: the first solver submission equals `initial_list / unit_list`, and a run with `scipy.__version__` monkeypatched to `1.16.0rc1` completes without crashing.
- `tests/minsearch/do.sh` still passes (`unit_list` defaults to 1, so reference output is unchanged).
- Full `tests/unit/` suite: 30 passed locally.

## Notes

- The new test files use `sys.path.insert(0, ...)` instead of `append` so that a stale installed `odatse` package cannot shadow `src/` (with `append`, an old site-packages install was picked up and the pre-existing unit tests failed locally). Once #55 lands with its shared `tests/unit/conftest.py`, this boilerplate can be folded into it.
- `parse_version` intentionally mirrors the `_parse_version` helper #55 adds in `odatse.util.toml`; after #55 is merged the two can be unified into this shared `odatse.util.version` module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)