### PR TITLE
Report rank-local errors from the owning rank at the CLI boundary

### DIFF
--- a/src/odatse/_main.py
+++ b/src/odatse/_main.py
@@ -64,6 +64,11 @@ def main(argv: Optional[Sequence[str]] = None):
 
         return alg.main()
     except exception.Error as e:
-        if odatse.mpi.rank() == 0:
+        # rank-local errors (see exception.Error.rank_local) exist only on the
+        # rank that failed, so gating on rank 0 would silence them entirely
+        if e.rank_local:
+            prefix = f"[rank {odatse.mpi.rank()}] " if odatse.mpi.size() > 1 else ""
+            print(f"{prefix}ERROR: {e}", file=sys.stderr)
+        elif odatse.mpi.rank() == 0:
             print(f"ERROR: {e}", file=sys.stderr)
         sys.exit(1)

--- a/src/odatse/algorithm/_algorithm.py
+++ b/src/odatse/algorithm/_algorithm.py
@@ -267,6 +267,10 @@ class AlgorithmBase(metaclass=ABCMeta):
             all_ok = error is None
 
         if error is not None:
+            if isinstance(error, exception.Error):
+                # this rank's own failure: have the CLI boundary report it
+                # from this rank (rank 0 may have no error to print)
+                error.rank_local = True
             raise error
         if not all_ok:
             raise odatse.mpi.OtherAlgorithmProcessError()

--- a/src/odatse/exception.py
+++ b/src/odatse/exception.py
@@ -7,9 +7,19 @@
 # If a copy of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 class Error(Exception):
-    """Base class of exceptions in odatse"""
+    """Base class of exceptions in odatse
 
-    pass
+    Attributes
+    ----------
+    rank_local : bool
+        True when the error occurred on this MPI rank specifically (e.g. a
+        checkpoint I/O failure re-raised through the phase consensus
+        protocol), as opposed to an error raised identically on every rank
+        (e.g. a config error). The CLI boundary prints rank-local errors from
+        the owning rank; all other errors are printed on rank 0 only.
+    """
+
+    rank_local = False
 
 
 class InputError(Error):

--- a/tests/unit/test_consensus.py
+++ b/tests/unit/test_consensus.py
@@ -87,3 +87,29 @@ def test_prepare_dispatch_failure_does_not_deadlock():
     assert raised
     survived = mpi.algcomm().allgather(True)
     assert len(survived) == mpi.algsize() and all(survived)
+
+
+# --- rank-local marking for the CLI error boundary (issue #60) ---
+
+def test_reach_consensus_marks_own_odatse_error_rank_local():
+    """When a rank re-raises its own odatse error through the consensus
+    protocol, the exception must be marked rank-local so the CLI boundary
+    (odatse._main.main) reports it from the owning rank, not only rank 0."""
+    import odatse.exception
+
+    alg = _bare()
+    err = odatse.exception.CheckpointError("boom")
+    assert err.rank_local is False
+    with pytest.raises(odatse.exception.CheckpointError):
+        alg._reach_consensus(err, np.array([0]))
+    assert err.rank_local is True
+
+
+def test_reach_consensus_leaves_foreign_exceptions_unmarked():
+    """Non-odatse exceptions propagate as-is (they surface as tracebacks on
+    the failing rank anyway)."""
+    alg = _bare()
+    err = ValueError("boom")
+    with pytest.raises(ValueError):
+        alg._reach_consensus(err, np.array([0]))
+    assert not hasattr(err, "rank_local")

--- a/tests/unit/test_main_errors.py
+++ b/tests/unit/test_main_errors.py
@@ -50,3 +50,43 @@ def test_main_converts_input_error_to_exit(monkeypatch):
     with pytest.raises(SystemExit) as excinfo:
         main([])
     assert excinfo.value.code == 1
+
+
+def test_main_reports_rank_local_error_from_owning_rank(monkeypatch, capsys):
+    """A rank-local error (e.g. a CheckpointError re-raised through the
+    consensus protocol on the failing rank) must be reported by the rank that
+    owns it — previously only rank 0 printed, so a failure on any other rank
+    killed the job with no diagnostic text anywhere (issue #60)."""
+    from odatse.exception import CheckpointError
+
+    err = CheckpointError("simulated per-rank failure")
+    err.rank_local = True
+
+    def boom(argv):
+        raise err
+    monkeypatch.setattr(odatse, "initialize", boom)
+    # pretend to be a non-zero rank of a 4-process run
+    monkeypatch.setattr(odatse.mpi, "rank", lambda: 2)
+    monkeypatch.setattr(odatse.mpi, "size", lambda: 4)
+
+    with pytest.raises(SystemExit) as excinfo:
+        main([])
+    assert excinfo.value.code == 1
+    captured = capsys.readouterr()
+    assert "[rank 2]" in captured.err
+    assert "simulated per-rank failure" in captured.err
+
+
+def test_main_global_error_prints_only_on_rank0(monkeypatch, capsys):
+    """Errors raised identically on all ranks (e.g. config errors) keep the
+    rank-0 gate so a bad input file is not reported once per process."""
+    def boom(argv):
+        raise InputError("global config error")
+    monkeypatch.setattr(odatse, "initialize", boom)
+    monkeypatch.setattr(odatse.mpi, "rank", lambda: 2)
+    monkeypatch.setattr(odatse.mpi, "size", lambda: 4)
+
+    with pytest.raises(SystemExit) as excinfo:
+        main([])
+    assert excinfo.value.code == 1
+    assert capsys.readouterr().err == ""


### PR DESCRIPTION
## Summary

Closes #60 (follow-up to the review of #55).

`odatse._main.main()` printed `exception.Error` only on global rank 0, but the phase consensus protocol delivers per-rank failures (e.g. a corrupt checkpoint on `--resume`) only to the failing rank — the peers exit silently via `OtherAlgorithmProcessError`. A checkpoint failure on any non-zero rank therefore killed the MPI job with **no diagnostic text anywhere**.

## Changes

- `exception.Error` gains a `rank_local` attribute (default `False`), documented as "this error occurred on this rank specifically".
- `AlgorithmBase._reach_consensus` sets `rank_local = True` when a rank re-raises its own odatse error — this is the one place that knows the failure is rank-local. Non-odatse exceptions are left untouched (they surface as tracebacks on the failing rank anyway).
- `_main.main()` prints rank-local errors from the owning rank, prefixed with `[rank N]` under MPI. Errors raised identically on all ranks (config errors, `Info.from_file` failures) keep the rank-0 gate, so a bad input file is still reported exactly once.

## Verification

End-to-end (the exact scenario from #60): 2-rank exchange run with checkpointing, then `--resume` with rank 1's `status.pickle` overwritten with garbage:

```
[rank 1] ERROR: failed to read checkpoint from .../output/1/status.pickle: pickle data was truncated
```

exit status 1 (previously: silent death with no output).

Tests: new unit tests for the consensus marking (`test_consensus.py`) and both boundary behaviors (`test_main_errors.py`: rank-local printed from rank 2 with prefix; global error stays rank-0-only). Full suite: serial 124 passed, `mpiexec -np 2` / `-np 4` 127 passed per rank.

Note: develop is not the default branch, so #60 will need a manual close on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)