### PR TITLE
Fix random_search deadlock under solver-level parallelism and make quasi-random sequences reproducible

### DIFF
--- a/doc/en/source/algorithm/random_search.rst
+++ b/doc/en/source/algorithm/random_search.rst
@@ -104,6 +104,9 @@ The following parameters can be set in the ``[algorithm]`` section.
   Format: Integer.
 
   Description: The seed for the pseudo-random number generator used to generate the parameters.
+  For quasi-random sequences, the seed is used for the scrambling of the sequence;
+  when specified, the generated point set becomes reproducible,
+  and is identical regardless of the number of MPI processes.
 
 
 Output files

--- a/doc/ja/source/algorithm/random_search.rst
+++ b/doc/ja/source/algorithm/random_search.rst
@@ -103,6 +103,9 @@ quasi-random sequence を使う場合は `scipy <https://scipy.org>`_ をイン�
   形式: 整数型。
 
   説明: パラメータ生成に用いる疑似乱数のシード。
+  quasi-random sequence の場合は数列のスクランブルに用いられ、
+  seed を指定すると生成される点列が再現可能になります。
+  点列は MPI の並列数によらず同一になります。
 
 
 出力ファイル

--- a/src/odatse/algorithm/random_search.py
+++ b/src/odatse/algorithm/random_search.py
@@ -59,7 +59,8 @@ class Algorithm(MapperMPIAlgorithm):
                 iter = self._random_iterator(info_param, self.rng)
             elif mode == "quasi-random":
                 seq = info_mode.get("sequence", "sobol")
-                iter = self._quasi_random_iterator(info_param, seq)
+                seed = info.algorithm.get("seed", None)
+                iter = self._quasi_random_iterator(info_param, seq, seed)
             else:
                 raise ValueError("ERROR: algorithm.mode.mode = {} is not supported".format(mode))
             # delayed setup
@@ -95,7 +96,23 @@ class Algorithm(MapperMPIAlgorithm):
 
         return RandomIterator(min_list, max_list, num_points, rng)
 
-    def _quasi_random_iterator(self, info_param, seq):
+    def _quasi_random_iterator(self, info_param, seq, seed=None):
+        """
+        Setup a quasi-random (low-discrepancy) point sequence.
+
+        Parameters
+        ----------
+        info_param
+            Dictionary containing parameters for setting up the points.
+        seq : str
+            Sequence type: "sobol", "halton", or "latin".
+        seed : int, optional
+            Seed for the scrambling of the sequence. The sequence is
+            generated on the algorithm-rank-0 process only, so a single
+            integer makes the whole point set reproducible independently
+            of the MPI configuration. If None, the scrambling differs
+            from run to run.
+        """
         from scipy.stats import qmc
 
         if "min_list" not in info_param:
@@ -119,11 +136,11 @@ class Algorithm(MapperMPIAlgorithm):
             d = len(min_list)
 
             if seq == "sobol":
-                sampler = qmc.Sobol(d, scramble=True, optimization=None)
+                sampler = qmc.Sobol(d, scramble=True, optimization=None, seed=seed)
             elif seq == "halton":
-                sampler = qmc.Halton(d, scramble=True, optimization=None)
+                sampler = qmc.Halton(d, scramble=True, optimization=None, seed=seed)
             elif seq == "latin":
-                sampler = qmc.LatinHypercube(d, scramble=True, strength=1, optimization=None)
+                sampler = qmc.LatinHypercube(d, scramble=True, strength=1, optimization=None, seed=seed)
             else:
                 raise ValueError("unknown sequence type {}".format(seq))
 

--- a/src/odatse/algorithm/random_search.py
+++ b/src/odatse/algorithm/random_search.py
@@ -54,16 +54,18 @@ class Algorithm(MapperMPIAlgorithm):
 
         info_param = info.algorithm.get("param", {})
 
-        if mode == "random":
-            iter = self._random_iterator(info_param, self.rng)
-        elif mode == "quasi-random":
-            seq = info_mode.get("sequence", "sobol")
-            iter = self._quasi_random_iterator(info_param, seq)
+        if odatse.mpi.run_on_algorithm():
+            if mode == "random":
+                iter = self._random_iterator(info_param, self.rng)
+            elif mode == "quasi-random":
+                seq = info_mode.get("sequence", "sobol")
+                iter = self._quasi_random_iterator(info_param, seq)
+            else:
+                raise ValueError("ERROR: algorithm.mode.mode = {} is not supported".format(mode))
+            # delayed setup
+            self._iter = iter
         else:
-            raise ValueError("ERROR: algorithm.mode.mode = {} is not supported".format(mode))
-
-        # delayed setup
-        self._iter = iter
+            self._iter = None
 
     def _random_iterator(self, info_param, rng):
         """

--- a/tests/parallel_solver/CMakeLists.txt
+++ b/tests/parallel_solver/CMakeLists.txt
@@ -82,6 +82,12 @@ add_test(
   WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/tests/parallel_solver/random_search
   )
 
+add_test(
+  NAME parallel_random_search_quasi
+  COMMAND sh do.sh
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/tests/parallel_solver/random_search_quasi
+  )
+
 # The do.sh scripts run "mpirun ... ${PYTHON:-python3}". Point PYTHON at the
 # interpreter CMake resolved (see top-level CMakeLists.txt) so mpirun does not
 # fall back to the system python3, which lacks the installed packages.

--- a/tests/parallel_solver/random_search_quasi/check_output.py
+++ b/tests/parallel_solver/random_search_quasi/check_output.py
@@ -1,0 +1,30 @@
+# Check the structure of the ColorMap file produced by the quasi-random
+# search. The scrambled Sobol sequence is not seeded, so the sampled points
+# differ from run to run and cannot be compared against a reference file.
+# Verify instead that all points were evaluated and lie within the search
+# range given in input.toml.
+import sys
+
+import numpy as np
+
+resfile = sys.argv[1]
+num_points = int(sys.argv[2])
+
+# search range; must match [algorithm.param] in input.toml
+min_list = [-6.0, -6.1]
+max_list = [6.0, 6.0]
+
+data = np.loadtxt(resfile, comments="#")
+
+if data.shape != (num_points, len(min_list) + 1):
+    sys.exit("ERROR: expected shape {}, got {}".format(
+        (num_points, len(min_list) + 1), data.shape))
+
+for k, (lo, hi) in enumerate(zip(min_list, max_list)):
+    if not (np.all(data[:, k] >= lo) and np.all(data[:, k] <= hi)):
+        sys.exit("ERROR: column {} out of range [{}, {}]".format(k, lo, hi))
+
+if not np.all(np.isfinite(data[:, -1])):
+    sys.exit("ERROR: fval contains non-finite values")
+
+print("OK: {} points within bounds".format(num_points))

--- a/tests/parallel_solver/random_search_quasi/do.sh
+++ b/tests/parallel_solver/random_search_quasi/do.sh
@@ -6,27 +6,49 @@ export OMP_NUM_THREADS=1
 export PYTHONUNBUFFERED=1
 export OMPI_MCA_rmaps_base_oversubscribe=1
 
-# Remove the output directory if it exists
-rm -rf output
+# Remove the output directories if they exist
+rm -rf output output1 output2 output_serial
 
-# Run the Python script with MPI
+# The quasi-random sequence is scrambled with the seed given in input.toml.
+# The points are generated on the algorithm-rank-0 process and distributed,
+# so the same seed must yield identical results independently of the MPI
+# configuration. The exact values depend on the scipy version, so instead of
+# comparing with a reference file, run the calculation three times and check
+# that the results agree with each other:
+#   run 1: 8 processes (nalg=4, nsolve=2)
+#   run 2: 8 processes (nalg=4, nsolve=2) -- determinism
+#   run 3: 1 process   (nalg=1, nsolve=1) -- independence of parallelism
+
 /usr/bin/time mpirun -np 8 ${PYTHON:-python3} ../parallel_solver.py --nalg 4 --nsolve 2 input.toml
+mv output output1
 
-# Define the result file path
-resfile=output/ColorMap.txt
+/usr/bin/time mpirun -np 8 ${PYTHON:-python3} ../parallel_solver.py --nalg 4 --nsolve 2 input.toml
+mv output output2
 
-# The scrambled Sobol sequence is not seeded, so the sampled points differ
-# from run to run. Check the structure of the output instead of comparing
-# with a reference file.
-echo check $resfile
+/usr/bin/time mpirun -np 1 ${PYTHON:-python3} ../parallel_solver.py --nalg 1 --nsolve 1 input.toml
+mv output output_serial
+
+resfile=output1/ColorMap.txt
+
 res=0
+
+# Check the structure of the result (number of points, bounds, finite values)
+echo check $resfile
 ${PYTHON:-python3} check_output.py $resfile 128 || res=$?
+
+# Check that two runs with the same seed give identical results
+echo diff output1/ColorMap.txt output2/ColorMap.txt
+diff output1/ColorMap.txt output2/ColorMap.txt || res=$?
+
+# Check that the result does not depend on the MPI configuration
+echo diff output1/ColorMap.txt output_serial/ColorMap.txt
+diff output1/ColorMap.txt output_serial/ColorMap.txt || res=$?
 
 # Check the result
 if [ $res -eq 0 ]; then
   echo TEST PASS
   true
 else
-  echo TEST FAILED: $resfile is broken or missing
+  echo TEST FAILED
   false
 fi

--- a/tests/parallel_solver/random_search_quasi/do.sh
+++ b/tests/parallel_solver/random_search_quasi/do.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+
+export OMP_NUM_THREADS=1
+
+export PYTHONUNBUFFERED=1
+export OMPI_MCA_rmaps_base_oversubscribe=1
+
+# Remove the output directory if it exists
+rm -rf output
+
+# Run the Python script with MPI
+/usr/bin/time mpirun -np 8 ${PYTHON:-python3} ../parallel_solver.py --nalg 4 --nsolve 2 input.toml
+
+# Define the result file path
+resfile=output/ColorMap.txt
+
+# The scrambled Sobol sequence is not seeded, so the sampled points differ
+# from run to run. Check the structure of the output instead of comparing
+# with a reference file.
+echo check $resfile
+res=0
+${PYTHON:-python3} check_output.py $resfile 128 || res=$?
+
+# Check the result
+if [ $res -eq 0 ]; then
+  echo TEST PASS
+  true
+else
+  echo TEST FAILED: $resfile is broken or missing
+  false
+fi

--- a/tests/parallel_solver/random_search_quasi/input.toml
+++ b/tests/parallel_solver/random_search_quasi/input.toml
@@ -1,0 +1,24 @@
+[base]
+dimension = 2
+output_dir = "output"
+
+[solver]
+name = "custom"
+delay = 0.01
+
+[runner]
+[runner.log]
+interval = 20
+
+[algorithm]
+name = "random_search"
+seed = 1234567
+
+[algorithm.mode]
+mode = "quasi-random"
+sequence = "sobol"
+
+[algorithm.param]
+max_list = [ 6.0,  6.0]
+min_list = [-6.0, -6.1]
+num_points = 128


### PR DESCRIPTION
## Summary

- Fix a crash/deadlock of the `random_search` algorithm when quasi-random mode is combined with solver-level MPI parallelism (`nsolve > 1`).
- Make quasi-random sequences reproducible by passing `algorithm.seed` to the samplers.
- Add a parallel regression test for quasi-random mode and update the algorithm reference (ja/en).

## Problem

`random_search.Algorithm.__init__` built its point iterator on **all** MPI processes, unlike `mapper_mpi`, which guards the construction with `odatse.mpi.run_on_algorithm()`.

Under solver-level parallelism, solver-worker processes have no algorithm communicator (`algcomm()` is `None`). In quasi-random mode the workers entered `ListIterator._setup` and crashed during `Algorithm.__init__` with:

```
AttributeError: 'NoneType' object has no attribute 'scatter'
```

The surviving algorithm-side processes then deadlocked waiting on a `Bcast` to the dead workers. Reproduced with:

```
mpirun -np 4 python tests/parallel_solver/parallel_solver.py --nalg 2 --nsolve 2 input.toml
```

with `[algorithm.mode] mode = "quasi-random"`. Plain `random` mode worked only by accident because `RandomIterator` performs no communication in its constructor, which is why the existing `tests/parallel_solver/random_search` test (random mode only) did not catch this.

## Changes

- **`fix(random_search)`**: guard the iterator construction with `odatse.mpi.run_on_algorithm()` and set `_iter = None` on solver-worker processes, matching `mapper_mpi`.
- **`feat(random_search)`**: pass `algorithm.seed` to the quasi-random samplers (Sobol / Halton / Latin hypercube), which were created with `scramble=True` but no seed. No new input parameter is introduced; when `seed` is not given, the previous (non-reproducible) behaviour is kept. Since the sequence is generated on the algorithm-rank-0 process only and then distributed, a fixed seed yields identical results independently of the MPI configuration.
- **`docs(random_search)`**: note in the ja/en algorithm reference that `algorithm.seed` also controls the scrambling of quasi-random sequences.

## Tests

New test `tests/parallel_solver/random_search_quasi` (registered in CMake as `parallel_random_search_quasi`):

- runs the same calculation twice with `--nalg 4 --nsolve 2` and once with `--nalg 1 --nsolve 1`, and requires the three `ColorMap.txt` files to agree exactly (determinism and independence of the MPI configuration);
- checks the structure of the output (number of evaluated points, bounds, finite values).

The exact sample values depend on the scipy version, so no reference file is used. Verified that without a seed the runs do differ, i.e. the diff checks genuinely exercise the seeding.

Regression: `pytest tests/unit` (120 passed), `tests/parallel_solver/random_search`, and `tests/mapper_random` all pass. Before the fix, the new test deadlocks; after the fix it completes and passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)