### PR TITLE
Checkpoint cleanups from the PR #55 review: consistent errors, O(1) rotation, centralized RNG restore

### DIFF
--- a/src/odatse/algorithm/_algorithm.py
+++ b/src/odatse/algorithm/_algorithm.py
@@ -13,7 +13,6 @@ import time
 import os
 import pathlib
 import pickle
-import shutil
 import copy
 
 import numpy as np
@@ -107,11 +106,14 @@ class AlgorithmBase(metaclass=ABCMeta):
     def _apply_state(self, data: dict, mode: str = "resume", restore_rng: bool = True) -> None:
         """Restore the base algorithm state from a checkpoint snapshot.
 
-        Validates the MPI configuration, restores the timer, and checks
-        that algorithm parameters are consistent.  Subclasses should call
+        Validates the MPI configuration, restores the timer, checks that
+        algorithm parameters are consistent, and restores the RNG state.
+        Subclasses should call
         ``super()._apply_state(data, mode=mode, restore_rng=restore_rng)``
-        and then handle their own fields (RNG restore, subclass-specific
-        ``_checkpoint_attrs``, continue-mode semantics, etc.).
+        and then handle their own subclass-specific fields
+        (``_checkpoint_attrs``, continue-mode semantics, etc.).  The RNG state
+        saved by ``__getstate__`` for every algorithm is restored here (guarded
+        by ``restore_rng``), so subclasses need not repeat it.
 
         Parameters
         ----------
@@ -127,6 +129,15 @@ class AlgorithmBase(metaclass=ABCMeta):
         assert odatse.mpi.algrank() == data["algrank"]
         self.timer = data["timer"]
         self._check_parameters(data["info"])
+        if restore_rng:
+            # Restore in place rather than rebinding self.rng: collaborators
+            # constructed in __init__ hold a reference to this object (e.g.
+            # the Monte Carlo StateSpace draws its proposals from it, and
+            # MeshGrid may capture it), and __init__ runs before the resume
+            # dispatch in prepare(). Rebinding would leave those collaborators
+            # on the stale un-restored RNG, silently splitting the random
+            # stream after a resume.
+            self.rng.set_state(data["rng"])
 
     @abstractmethod
     def __init__(
@@ -464,10 +475,6 @@ class AlgorithmBase(metaclass=ABCMeta):
             Whether to restore the RNG state.
         """
         data = self._load_data(filename)
-        if not data:
-            raise exception.CheckpointError(
-                f"failed to load checkpoint from {filename}"
-            )
         self._apply_state(data, mode=mode, restore_rng=restore_rng)
 
     # ------------------------------------------------------------------
@@ -593,17 +600,19 @@ class AlgorithmBase(metaclass=ABCMeta):
             ) from e
 
         # Rotate the older backup generations: .(ngen-1) -> .ngen, ..., .1 -> .2
+        # (os.replace is an atomic O(1) rename on every platform; shutil.move
+        # would fall back to copy+delete on Windows when the target exists)
         for idx in range(ngen-1, 0, -1):
             fn_from = Path(filename + "." + str(idx))
             fn_to = Path(filename + "." + str(idx+1))
             if fn_from.exists():
-                shutil.move(fn_from, fn_to)
-        # Keep the current checkpoint as .1 by *copying* it (not moving), so
-        # that `filename` always points to a complete checkpoint -- there is no
-        # window in which it is missing. Then atomically swap in the new one
-        # with os.replace(), which is the only step that touches `filename`.
+                os.replace(fn_from, fn_to)
+        # Move the current checkpoint aside to .1 with an atomic rename (O(1),
+        # no re-read/re-write of the pickle), then atomically swap in the new
+        # one. There is a tiny window between the two renames in which
+        # `filename` is absent; `_load_data` covers it by falling back to .1.
         if ngen > 0 and Path(filename).exists():
-            shutil.copy2(Path(filename), Path(filename + "." + str(1)))
+            os.replace(Path(filename), Path(filename + "." + str(1)))
         os.replace(Path(filename + ".tmp"), Path(filename))
         print("save_state: write to {}".format(filename))
 
@@ -639,8 +648,9 @@ class AlgorithmBase(metaclass=ABCMeta):
                 ) from e
             print("load_state: load from {}".format(fn))
         else:
-            print("ERROR: file {} not exist.".format(filename))
-            data = {}
+            raise exception.CheckpointError(
+                f"checkpoint file {filename} does not exist"
+            )
         return data
 
     def _show_parameters(self):

--- a/src/odatse/algorithm/bayes.py
+++ b/src/odatse/algorithm/bayes.py
@@ -278,10 +278,10 @@ class Algorithm(odatse.algorithm.AlgorithmBase):
     def _apply_state(self, data: dict, mode: str = "resume", restore_rng: bool = True) -> None:
         """Restore algorithm state from a checkpoint snapshot.
 
-        Delegates MPI validation, timer restore, and parameter check to the
-        base class, optionally restores both the instance RNG and the global
-        numpy RNG, applies the Bayes-specific fields, then loads the physbo
-        policy from the saved files.
+        Delegates MPI validation, timer restore, parameter check, and the
+        instance RNG restore to the base class; additionally restores the
+        global numpy RNG used by physbo, applies the Bayes-specific fields,
+        then loads the physbo policy from the saved files.
 
         ``_load_state()`` is not overridden; the base class implementation
         calls ``self._apply_state()`` (this method), so policy files are
@@ -299,8 +299,6 @@ class Algorithm(odatse.algorithm.AlgorithmBase):
         """
         super()._apply_state(data, mode=mode, restore_rng=restore_rng)
         if restore_rng:
-            self.rng = np.random.RandomState()
-            self.rng.set_state(data["rng"])
             np.random.set_state(data["random_number"])
         for attr in Algorithm._checkpoint_attrs:
             setattr(self, attr, data[attr])

--- a/src/odatse/algorithm/montecarlo.py
+++ b/src/odatse/algorithm/montecarlo.py
@@ -332,10 +332,10 @@ class AlgorithmBase(odatse.algorithm.AlgorithmBase):
     def _apply_state(self, data: dict, mode: str = "resume", restore_rng: bool = True) -> None:
         """Restore algorithm state from a checkpoint snapshot.
 
-        Delegates MPI validation, timer restore, and parameter check to the
-        base class, optionally restores the RNG, then applies every field
-        listed in ``montecarlo.AlgorithmBase._checkpoint_attrs``.  Subclasses
-        that need additional fields should override this method, call
+        Delegates MPI validation, timer restore, parameter check, and RNG
+        restore to the base class, then applies every field listed in
+        ``montecarlo.AlgorithmBase._checkpoint_attrs``.  Subclasses that need
+        additional fields should override this method, call
         ``super()._apply_state(data, mode=mode, restore_rng=restore_rng)``,
         then handle their own fields.
 
@@ -351,9 +351,6 @@ class AlgorithmBase(odatse.algorithm.AlgorithmBase):
             when *False* a fresh RNG state is kept (``--reset_rand`` mode).
         """
         super()._apply_state(data, mode=mode, restore_rng=restore_rng)
-        if restore_rng:
-            self.rng = np.random.RandomState()
-            self.rng.set_state(data["rng"])
         for attr in AlgorithmBase._checkpoint_attrs:
             setattr(self, attr, data[attr])
 

--- a/src/odatse/algorithm/ttopt.py
+++ b/src/odatse/algorithm/ttopt.py
@@ -582,9 +582,6 @@ class Algorithm(odatse.algorithm.AlgorithmBase):
                 f"current config gives {self.n_q_dims}. "
                 "Check that p_points and q_points match the original run."
             )
-        if restore_rng:
-            self.rng = np.random.RandomState()
-            self.rng.set_state(data["rng"])
         for attr in Algorithm._checkpoint_attrs:
             setattr(self, attr, data[attr])
 
@@ -606,10 +603,6 @@ class Algorithm(odatse.algorithm.AlgorithmBase):
             applied.
         """
         data = self._load_data(filename)
-        if not data:
-            raise odatse.exception.CheckpointError(
-                f"failed to load checkpoint from {filename}"
-            )
         self._resume_data = data
         self._resume_restore_rng = restore_rng
 

--- a/tests/unit/test_checkpoint_io.py
+++ b/tests/unit/test_checkpoint_io.py
@@ -101,6 +101,16 @@ def test_load_state_missing_file_raises_checkpoint_error(tmp_path):
         alg._load_state(fn, mode="resume")
 
 
+def test_load_data_missing_all_generations_raises(tmp_path):
+    """A fully-missing checkpoint (no current file and no .1 backup) must raise
+    CheckpointError directly from _load_data, not return an empty-dict sentinel
+    that callers have to re-check."""
+    alg = _alg()
+    fn = str(tmp_path / "does_not_exist.pickle")
+    with pytest.raises(CheckpointError):
+        alg._load_data(filename=fn)
+
+
 def test_load_data_corrupt_file_raises_checkpoint_error(tmp_path):
     """An unreadable/corrupt checkpoint must raise CheckpointError."""
     alg = _alg()

--- a/tests/unit/test_ttopt_resume.py
+++ b/tests/unit/test_ttopt_resume.py
@@ -62,6 +62,25 @@ def test_apply_state_restores_rng_and_fields():
     assert alg.cache_hits == 3
 
 
+def test_apply_state_restores_rng_in_place():
+    """The RNG must be restored *in place*, not rebound to a new object:
+    collaborators constructed in __init__ (e.g. the Monte Carlo StateSpace,
+    which draws proposals) capture a reference to alg.rng, and __init__ runs
+    before the resume dispatch. Rebinding would leave them on the stale
+    un-restored generator, silently splitting the random stream on resume."""
+    alg = _bare()
+    alg.n_q_dims = 1
+    captured = alg.rng  # what a collaborator would hold
+
+    ref = np.random.RandomState(12345)
+    data = _snapshot(n_q_dims=1, rng_state=ref.get_state())
+    alg._apply_state(data, restore_rng=True)
+
+    assert alg.rng is captured
+    # the shared object carries the restored stream
+    np.testing.assert_array_equal(captured.rand(4), ref.rand(4))
+
+
 def test_apply_state_skips_rng_when_disabled():
     alg = _bare()
     alg.n_q_dims = 1


### PR DESCRIPTION
## Summary

Follow-ups to the [PR #55 review](https://github.com/issp-center-dev/ODAT-SE/pull/55#pullrequestreview-4615284423), covering the non-regression findings. The two regressions from the same review are handled separately (#60 → `fix/mpi-error-reporting`, #61 → `fix/separateT-fd-exhaustion`) and do not overlap with this PR.

## Changes

### 1. `_load_data` raises `CheckpointError` on a missing checkpoint (consistency)

The corrupt-read path already raised `CheckpointError`, but the missing-file path still used the old pattern: an unguarded `print("ERROR: ...")` on every rank plus an empty-dict sentinel that both callers had to re-check. The missing-file path now raises `CheckpointError` directly, and the duplicated `if not data:` guards in `AlgorithmBase._load_state` and `ttopt._load_state` are dropped.

This also composes with the rank-local error reporting in `fix/mpi-error-reporting`: a missing checkpoint on one rank surfaces as a `CheckpointError` on that rank and is reported from it.

### 2. Checkpoint rotation back to O(1) atomic renames (performance)

`_save_data` rotated the current checkpoint to `.1` with `shutil.copy2`, re-reading and re-writing the entire pickle on every checkpoint save, on every rank — real bandwidth for PAMC/exchange runs with many walkers. The rotation now uses `os.replace` throughout, including the backup-generation loop (where `shutil.move` degrades to copy+delete on Windows when the target exists).

Crash-recoverability is unchanged: the write is still tmp + fsync + atomic swap, and `_load_data` already falls back to `.1` for the tiny window between the two renames (covered by `test_current_file_survives_crash_at_atomic_swap` and `test_load_falls_back_to_generation_1`).

### 3. RNG restore centralized in `AlgorithmBase._apply_state` — and made in-place (deduplication + bug fix)

The guarded RNG restore was copied verbatim into `montecarlo`, `bayes`, and `ttopt`. Since `__getstate__` unconditionally saves `"rng"` for every algorithm, the restore is hoisted into `AlgorithmBase._apply_state` (guarded by `restore_rng`); `bayes` keeps only its extra global-numpy-RNG restore.

While hoisting, a latent resume bug was found in the copied pattern itself: it **rebound** `self.rng` to a new `RandomState`. Collaborators constructed in `__init__` capture a *reference* to the RNG object — the Monte Carlo `StateSpace` draws its **proposals** from it (`state.py`), while the **acceptance** step draws from `self.rng` (`montecarlo.py`) — and `__init__` runs before the resume dispatch in `prepare()`. Rebinding therefore restored the acceptance stream but left the proposal stream on the stale, freshly-seeded generator, silently splitting the random stream after a resume. The centralized restore applies the state **in place** (`self.rng.set_state(...)`), preserving the shared reference so both streams continue from the checkpoint.

Not affected: `random_search`'s `RandomIterator` snapshots and restores its own `rng_state` independently, and the `--reset_rand` path (`restore_rng=False`) is unchanged.

## Tests

- New: `test_load_data_missing_all_generations_raises` — a fully-missing checkpoint raises `CheckpointError` from `_load_data` itself.
- New: `test_apply_state_restores_rng_in_place` — the restored RNG is the *same object* a collaborator captured, and it carries the restored stream.
- Existing coverage validating the rotation change and the hoisted restore (`test_checkpoint_io.py`, `test_ttopt_resume.py`) passes unchanged.
- Full serial unit suite: **122 passed, 4 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)