### PR TITLE
Reuse odatse.util.toml.load in summarize_each_T instead of a weaker inline version check

### DIFF
--- a/src/odatse/scripts/summarize_each_T.py
+++ b/src/odatse/scripts/summarize_each_T.py
@@ -29,17 +29,13 @@ def read_toml(input_filename):
     dict
         Contains 'replica_per_proc' and 'output_dir' extracted from the config.
     """
-    try:
-        import tomllib
-    except ImportError:
-        import tomli as tomllib
-        # Numeric comparison: a string compare is wrong (e.g. "1.10.0" < "1.2.0").
-        major_minor = tuple(int(x) for x in tomllib.__version__.split(".")[:2])
-        if major_minor < (1, 2):
-            raise ImportError("tomli 1.2.0 or later required")
+    # Reuse the library loader, which handles the tomllib/tomli/toml fallback
+    # and the robust version check in one place (a bare int() per component
+    # crashes on pre-release versions like "1.2rc1"). Imported lazily so the
+    # -n code path keeps working without any TOML library installed.
+    from odatse.util.toml import load
 
-    with open(input_filename, "rb") as fp:
-        dict_toml = tomllib.load(fp)
+    dict_toml = load(input_filename)
 
     # This tool targets PAMC output; give a clear error (not a bare KeyError)
     # if the config is for another algorithm or lacks the field. Pass -n to


### PR DESCRIPTION
## Summary

Follow-up to the [PR #55 review](https://github.com/issp-center-dev/ODAT-SE/pull/55#pullrequestreview-4615284423) (the `[duplication]` finding on the version-compare fix), applied at the file's new location after the script2command move (#64).

## Problem

PR #55 fixed the lexicographic version-compare bug twice, with two different implementations. The library got a robust, unit-tested parser (now `odatse.util.version.parse_version`, which tolerates pre-release suffixes), while `summarize_each_T` kept a weaker inline copy:

```python
major_minor = tuple(int(x) for x in tomllib.__version__.split(".")[:2])
```

`int(x)` raises `ValueError` on a version like `1.2rc1` — exactly the case the library helper was written to handle. Keeping two implementations also means future fixes have to happen in both places.

## Change

`read_toml` in `src/odatse/scripts/summarize_each_T.py` now delegates to `odatse.util.toml.load`, which handles the `tomllib` / `tomli` / `toml` fallback and the robust version check in one place.

Two points specific to the new layout:

- Since the script now lives inside the package (`odatse.scripts`, entry point `odatse_summarize_each_T`), depending on `odatse.util.toml` is natural — no path manipulation needed.
- The import stays **lazy inside `read_toml`**, so the `-n` code path (replica count given on the command line, no TOML read) keeps working without any TOML library installed, as before.

## Tests

- Functional check: `read_toml` returns the expected `{replica_per_proc, output_dir}` for a PAMC config via the library loader.
- Full serial unit suite: **120 passed, 4 skipped** (unchanged from `develop`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)