### PR TITLE
fix(solver): rename SolverBase.evaluate parameter arg to args

### DIFF
--- a/src/odatse/solver/_solver.py
+++ b/src/odatse/solver/_solver.py
@@ -64,7 +64,7 @@ class SolverBase(object, metaclass=ABCMeta):
         return self._name
 
     @abstractmethod
-    def evaluate(self, x: np.ndarray, arg: tuple = ()) -> float:
+    def evaluate(self, x: np.ndarray, args: tuple = ()) -> float:
         """
         Evaluate the solver with the given parameters.
 
@@ -72,7 +72,7 @@ class SolverBase(object, metaclass=ABCMeta):
         ----------
         x : np.ndarray
             Input data array.
-        arg : tuple, optional
+        args : tuple, optional
             Additional arguments for evaluation. Defaults to ().
 
         Raises


### PR DESCRIPTION
## Overview

The abstract signature of `SolverBase.evaluate` named its second
parameter `arg` (singular), while everything else in the project uses
`args` (plural): the built-in implementation
(`odatse.solver.function`), the customization guide, and all tutorial
code examples. This PR renames the base-class parameter (and its
docstring entry) to `args` so that the whole codebase and
documentation agree.

```diff
-    def evaluate(self, x: np.ndarray, arg: tuple = ()) -> float:
+    def evaluate(self, x: np.ndarray, args: tuple = ()) -> float:
```

## Why

The `Runner` passes the argument positionally, so the mismatch never
broke framework calls. It still caused three problems:

- The auto-generated API reference showed `arg` for the base class
  while the manual documents `args`, contradicting each other.
- Code that calls `evaluate` with a keyword argument (e.g. in user
  test code) written against one signature fails with a `TypeError`
  against the other.
- Signature-consistency linters (e.g. pylint W0237
  `arguments-renamed`) flag every subclass that follows the
  documented `args` convention.

## Compatibility

Only external code calling `evaluate(x, arg=...)` by keyword would be
affected. The documentation has never advertised the name `arg`, so
the practical risk is negligible. Positional callers, including the
framework itself, are unaffected.

## Tests

- `pytest tests/unit`: 129 passed, 4 skipped (no new failures).
- Verified `arg` had no other occurrences in `src/` or `tests/`
  (implementations and test solvers already use `args`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)