### PR TITLE
Support method selection and basin-hopping global optimization in minsearch

### DIFF
--- a/doc/en/source/algorithm/minsearch.rst
+++ b/doc/en/source/algorithm/minsearch.rst
@@ -2,7 +2,8 @@
 Nelder-Mead method ``minsearch``
 ================================
 
-.. _scipy.optimize.minimize: https://docs.scipy.org/doc/scipy/reference/optimize.minimize-neldermead.html
+.. _scipy.optimize.minimize: https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html
+.. _scipy.optimize.basinhopping: https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.basinhopping.html
 
 When ``minsearch`` is selcted, the optimization by the `Nelder-Mead method <https://en.wikipedia.org/wiki/Nelder%E2%80%93Mead_method>`_ (a.k.a. downhill simplex method) will be done. In the Nelder-Mead method, assuming the dimension of the parameter space is :math:`D`, the optimal solution is searched by systematically moving pairs of :math:`D+1` coordinate points according to the value of the objective function at each point.
 
@@ -124,7 +125,40 @@ listed below apply only when ``method`` is "Nelder-Mead".
 
   Format: Integer (default: 100000)
 
-  Description: Maximum number of times to evaluate the objective function. 
+  Description: Maximum number of times to evaluate the objective function.
+
+- ``basinhopping``
+
+  Format: Boolean or table (default: false)
+
+  Description:
+  Enables global optimization by `scipy.optimize.basinhopping`_ (basin hopping),
+  with the method specified by ``method`` used as the local minimizer of each hop.
+  ``basinhopping = true`` runs with the scipy default parameters.
+  Defining a ``[algorithm.minimize.basinhopping]`` sub-table also enables it;
+  its entries (``niter``, ``stepsize``, ``T``, ...) are passed verbatim as
+  arguments of `scipy.optimize.basinhopping`_.
+  If an argument name not accepted by scipy is given, the program stops with
+  an error before the optimization starts.
+  Arguments managed by ODAT-SE (``take_step``, ``seed``, ...) cannot be set.
+
+  Random hops are clipped into the search region (``min_list`` / ``max_list``).
+  The random numbers are initialized from ``seed`` in the ``[algorithm]`` section.
+  Note that the local optimization runs ``niter`` + 1 times in total, so the
+  total number of solver evaluations is roughly
+  (``niter`` + 1) x (evaluations per local optimization).
+  When enabled, ``initial_scale_list`` (the initial simplex) is not used.
+
+  Example:
+
+  .. code-block:: toml
+
+      [algorithm.minimize]
+      method = "Nelder-Mead"
+
+      [algorithm.minimize.basinhopping]
+      niter = 50
+      stepsize = 0.5
 
 
 Output files
@@ -155,6 +189,15 @@ The following is an example of the output.
 
 Records every call of the objective function during the optimization.
 Each line contains the call number, the values of the variables, and the value of the objective function, in that order.
+
+``BasinHoppingData.txt``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Written only when ``basinhopping`` is enabled.
+For each local optimization (one from the initial point plus ``niter`` hops),
+it outputs the hop number, the values of the variables at the local minimum,
+the value of the objective function, and whether the hop was accepted (1/0),
+in that order.
 
 ``res.txt``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/en/source/algorithm/minsearch.rst
+++ b/doc/en/source/algorithm/minsearch.rst
@@ -1,17 +1,28 @@
-================================
-Nelder-Mead method ``minsearch``
-================================
+=============================================
+Optimization by scipy.optimize ``minsearch``
+=============================================
 
 .. _scipy.optimize.minimize: https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html
 .. _scipy.optimize.basinhopping: https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.basinhopping.html
 
-When ``minsearch`` is selcted, the optimization by the `Nelder-Mead method <https://en.wikipedia.org/wiki/Nelder%E2%80%93Mead_method>`_ (a.k.a. downhill simplex method) will be done. In the Nelder-Mead method, assuming the dimension of the parameter space is :math:`D`, the optimal solution is searched by systematically moving pairs of :math:`D+1` coordinate points according to the value of the objective function at each point.
+``minsearch`` performs optimization using SciPy's `scipy.optimize.minimize`_ function.
+The optimization method is selected by the ``method`` parameter of the
+``[algorithm.minimize]`` section. The default is the
+`Nelder-Mead method <https://en.wikipedia.org/wiki/Nelder%E2%80%93Mead_method>`_
+(a.k.a. downhill simplex method), and the other methods accepted by
+`scipy.optimize.minimize`_ (Powell, COBYLA, ...) can also be chosen.
+In the Nelder-Mead method, assuming the dimension of the parameter space is
+:math:`D`, the optimal solution is searched by systematically moving pairs of
+:math:`D+1` coordinate points according to the value of the objective function
+at each point.
 
 An important hyperparameter is the initial value of the coordinates.
-Although it is more stable than the simple steepest descent method, it still has the problem of being trapped in the local optimum solution, so it is recommended to repeat the calculation with different initial values several times to check the results.
-
-In ODAT-SE, the Scipy's function ``scipy.optimize.minimize(method="Nelder-Mead")`` is used.
-For details, see `the official document <https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html#scipy.optimize.minimize>`_ .
+Since these local optimization methods have the problem of being trapped in a
+local optimum, it is recommended to repeat the calculation with different
+initial values several times to check the results, or to enable the optional
+global optimization by basin hopping (`scipy.optimize.basinhopping`_), which
+repeats a random hop followed by a local optimization with the selected method
+(see the ``basinhopping`` parameter below).
 
 
 Preparation
@@ -54,7 +65,7 @@ It has subsections ``param`` and ``minimize``.
 
   Description:
   Minimum value of each parameter.
-  When a parameter falls below this value during the Nelson-Mead method,
+  When a parameter falls below this value during the optimization,
   the solver is not evaluated and the value is considered infinite.
 
 - ``max_list``
@@ -63,7 +74,7 @@ It has subsections ``param`` and ``minimize``.
 
   Description:
   Maximum value of each parameter.
-  When a parameter exceeds this value during the Nelson-Mead method,
+  When a parameter exceeds this value during the optimization,
   the solver is not evaluated and the value is considered infinite.
 
 ``[algorithm.minimize]`` section
@@ -217,4 +228,5 @@ The following is an example of the output.
 
 Restart
 ~~~~~~~~~~~
-The restarting is not supported for the optimization by the Nelder-Mead method.
+Restarting is not supported by the ``minsearch`` algorithm,
+regardless of the selected method and whether basin hopping is enabled.

--- a/doc/en/source/algorithm/minsearch.rst
+++ b/doc/en/source/algorithm/minsearch.rst
@@ -68,17 +68,39 @@ It has subsections ``param`` and ``minimize``.
 ``[algorithm.minimize]`` section
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Set the hyperparameters for the Nelder-Mead method.
+Set the optimization method and its hyperparameters.
 See the documentation of `scipy.optimize.minimize`_ for details.
+
+All parameters other than ``method`` and ``initial_scale_list`` are passed
+verbatim to the ``options`` argument of `scipy.optimize.minimize`_.
+If a parameter name not accepted by the selected method is given,
+the program stops with an error before the optimization starts.
+The default values of ``xatol``, ``fatol``, ``maxiter``, and ``maxfev``
+listed below apply only when ``method`` is "Nelder-Mead".
+
+- ``method``
+
+  Format: String (default: "Nelder-Mead")
+
+  Description:
+  Name of the optimization method, passed as-is to the ``method`` argument of `scipy.optimize.minimize`_.
+  Examples: "Nelder-Mead", "Powell", "COBYLA".
+  Note that for gradient-based methods (BFGS, CG, ...) the gradient is evaluated by numerical differentiation,
+  which costs dimension+1 solver evaluations per gradient evaluation.
+  The search region (``min_list`` / ``max_list``) is passed as the ``bounds`` argument of scipy
+  for methods that support it (Powell, L-BFGS-B, TNC, SLSQP, trust-constr, COBYLA, COBYQA).
+  For the Nelder-Mead method, out-of-range points are handled as before
+  by treating the objective function value as infinity.
 
 - ``initial_scale_list``
 
-  Format: List of float. The length should match the value of dimension. 
+  Format: List of float. The length should match the value of dimension.
 
   Description:
   The difference value that is shifted from the initial value in order to create the initial simplex for the Nelder-Mead method.
   The ``initial_simplex`` is given by the sum of ``initial_list`` and the dimension of the ``initial_list`` plus one component of the ``initial_scale_list``.
   If not defined, scales at each dimension are set to 0.25.
+  Used only when ``method`` is "Nelder-Mead".
 
 - ``xatol``
 

--- a/doc/en/source/algorithm/minsearch.rst
+++ b/doc/en/source/algorithm/minsearch.rst
@@ -1,11 +1,12 @@
-=============================================
-Optimization by scipy.optimize ``minsearch``
-=============================================
+============================================================
+Optimization by local optimization algorithms ``minsearch``
+============================================================
 
 .. _scipy.optimize.minimize: https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html
 .. _scipy.optimize.basinhopping: https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.basinhopping.html
 
-``minsearch`` performs optimization using SciPy's `scipy.optimize.minimize`_ function.
+``minsearch`` performs optimization by local optimization algorithms.
+It is implemented on top of SciPy's `scipy.optimize.minimize`_ function.
 The optimization method is selected by the ``method`` parameter of the
 ``[algorithm.minimize]`` section. The default is the
 `Nelder-Mead method <https://en.wikipedia.org/wiki/Nelder%E2%80%93Mead_method>`_

--- a/doc/en/source/algorithm/minsearch.rst
+++ b/doc/en/source/algorithm/minsearch.rst
@@ -72,7 +72,8 @@ It has subsections ``param`` and ``minimize``.
 Set the optimization method and its hyperparameters.
 See the documentation of `scipy.optimize.minimize`_ for details.
 
-All parameters other than ``method`` and ``initial_scale_list`` are passed
+All parameters other than the ODAT-SE-specific keys ``method``,
+``initial_scale_list``, and ``basinhopping`` (described below) are passed
 verbatim to the ``options`` argument of `scipy.optimize.minimize`_.
 If a parameter name not accepted by the selected method is given,
 the program stops with an error before the optimization starts.

--- a/doc/ja/source/algorithm/minsearch.rst
+++ b/doc/ja/source/algorithm/minsearch.rst
@@ -65,8 +65,28 @@ ODAT-SEは、SciPy の ``scipy.optimize.minimize(method="Nelder-Mead")`` 関数�
 ``[algorithm.minimize]`` セクション
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Nelder-Mead 法のハイパーパラメータを設定します。
+最適化手法とそのハイパーパラメータを設定します。
 詳細は `scipy.optimize.minimize`_ のドキュメントを参照してください。
+
+``method`` と ``initial_scale_list`` 以外のパラメータは、そのまま
+`scipy.optimize.minimize`_ の ``options`` 引数に渡されます。
+選択した手法が受け付けないパラメータ名が指定された場合は、
+最適化を開始する前にエラーで終了します。
+以下に挙げる ``xatol``, ``fatol``, ``maxiter``, ``maxfev`` のデフォルト値は
+``method`` が "Nelder-Mead" の場合にのみ適用されます。
+
+- ``method``
+
+  形式: string型 (default: "Nelder-Mead")
+
+  説明: 最適化手法の名前。 `scipy.optimize.minimize`_ の ``method`` 引数にそのまま渡されます。
+  例: "Nelder-Mead", "Powell", "COBYLA" など。
+  勾配を必要とする手法 (BFGS, CG など) では、勾配が数値差分で評価されるため
+  1回の勾配評価あたり次元数+1回のソルバー実行が発生することに注意してください。
+  また、探索範囲 (``min_list`` / ``max_list``) は、bounds に対応した手法
+  (Powell, L-BFGS-B, TNC, SLSQP, trust-constr, COBYLA, COBYQA) では
+  scipy の ``bounds`` 引数として渡されます。
+  Nelder-Mead 法では従来通り、範囲外の点で目的関数値を無限大とみなす方法で処理されます。
 
 - ``initial_scale_list``
 
@@ -75,6 +95,7 @@ Nelder-Mead 法のハイパーパラメータを設定します。
   説明: Nelder-Mead 法の初期 simplex を作るために、初期値からずらす差分。
   ``initial_list`` と、 ``initial_list`` に ``initial_scale_list`` の成分ひとつを足してできるdimension 個の点を 合わせたものが ``initial_simplex`` として使われます。
   定義しなかった場合、各次元に 0.25 が設定されます。
+  ``method`` が "Nelder-Mead" の場合のみ使用されます。
 
 - ``xatol``
 

--- a/doc/ja/source/algorithm/minsearch.rst
+++ b/doc/ja/source/algorithm/minsearch.rst
@@ -2,7 +2,8 @@
 Nelder-Mead 法 ``minsearch``
 ===============================
 
-.. _scipy.optimize.minimize: https://docs.scipy.org/doc/scipy/reference/optimize.minimize-neldermead.html
+.. _scipy.optimize.minimize: https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html
+.. _scipy.optimize.basinhopping: https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.basinhopping.html
 
 ``minsearch`` は `Nelder-Mead 法 <https://en.wikipedia.org/wiki/Nelder%E2%80%93Mead_method>`_ (a.k.a. downhill simplex 法) によって最適化を行います。
 Nelder-Mead 法では、 パラメータ空間の次元を :math:`D` として、 :math:`D+1` 個の座標点の組を、各点での目的関数の値に応じて系統的に動かすことで最適解を探索します。
@@ -121,6 +122,36 @@ ODAT-SEは、SciPy の ``scipy.optimize.minimize(method="Nelder-Mead")`` 関数�
 
   説明: 目的関数を評価する回数の最大値
 
+- ``basinhopping``
+
+  形式: bool型 または テーブル (default: false)
+
+  説明: `scipy.optimize.basinhopping`_ による大域最適化(ベイスンホッピング法)を有効にします。
+  ``method`` で指定した手法が各ホップの局所最適化に使われます。
+  ``basinhopping = true`` とした場合は scipy のデフォルトパラメータで実行されます。
+  サブテーブル ``[algorithm.minimize.basinhopping]`` を定義した場合も有効化され、
+  その中のパラメータ (``niter``, ``stepsize``, ``T`` など) はそのまま
+  `scipy.optimize.basinhopping`_ の引数として渡されます。
+  受け付けられないパラメータ名が指定された場合は、最適化を開始する前にエラーで終了します。
+  ``take_step``, ``seed`` など ODAT-SE が管理する引数は指定できません。
+
+  ランダムなホップは探索範囲 (``min_list`` / ``max_list``) の内側に収まるように
+  クリップされます。乱数は ``[algorithm]`` セクションの ``seed`` から初期化されます。
+  局所最適化が合計 ``niter`` + 1 回実行されるため、ソルバーの総評価回数は
+  おおよそ (``niter`` + 1) × (局所最適化 1 回あたりの評価回数) となる点に注意してください。
+  有効時には ``initial_scale_list`` (初期 simplex) は使用されません。
+
+  設定例:
+
+  .. code-block:: toml
+
+      [algorithm.minimize]
+      method = "Nelder-Mead"
+
+      [algorithm.minimize.basinhopping]
+      niter = 50
+      stepsize = 0.5
+
 
 出力ファイル
 ~~~~~~~~~~~~~~~~~
@@ -149,6 +180,14 @@ ODAT-SEは、SciPy の ``scipy.optimize.minimize(method="Nelder-Mead")`` 関数�
 
 最適化の途中で目的関数が呼び出されるたびに、その情報を記録します。
 各行には、呼び出し番号、変数の値、目的関数の値がこの順に出力されます。
+
+``BasinHoppingData.txt``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+``basinhopping`` が有効な場合のみ出力されます。
+局所最適化 1 回ごと(初期点からの 1 回 + ``niter`` 回のホップ)に、
+ホップ番号、局所最適化で得られた変数の値、目的関数の値、
+そのホップが受理されたかどうか (1/0) をこの順に出力します。
 
 ``res.txt``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/ja/source/algorithm/minsearch.rst
+++ b/doc/ja/source/algorithm/minsearch.rst
@@ -1,18 +1,23 @@
-===============================
-Nelder-Mead 法 ``minsearch``
-===============================
+==========================================
+scipy.optimize による最適化 ``minsearch``
+==========================================
 
 .. _scipy.optimize.minimize: https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html
 .. _scipy.optimize.basinhopping: https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.basinhopping.html
 
-``minsearch`` は `Nelder-Mead 法 <https://en.wikipedia.org/wiki/Nelder%E2%80%93Mead_method>`_ (a.k.a. downhill simplex 法) によって最適化を行います。
+``minsearch`` は SciPy の `scipy.optimize.minimize`_ 関数を用いて最適化を行います。
+最適化手法は ``[algorithm.minimize]`` セクションの ``method`` パラメータで選択します。
+デフォルトは `Nelder-Mead 法 <https://en.wikipedia.org/wiki/Nelder%E2%80%93Mead_method>`_
+(a.k.a. downhill simplex 法) で、 `scipy.optimize.minimize`_ が受け付ける
+その他の手法 (Powell, COBYLA など) も選択できます。
 Nelder-Mead 法では、 パラメータ空間の次元を :math:`D` として、 :math:`D+1` 個の座標点の組を、各点での目的関数の値に応じて系統的に動かすことで最適解を探索します。
 
 重要なハイパーパラメータとして、座標の初期値があります。
-局所最適解にトラップされるという問題があるので、初期値を変えた計算を何回か繰り返して結果を確認することをおすすめします。
-
-ODAT-SEは、SciPy の ``scipy.optimize.minimize(method="Nelder-Mead")`` 関数を用いています。
-詳しくは `公式ドキュメント <https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html#scipy.optimize.minimize>`_ をご参照ください。
+これらの局所最適化手法には局所最適解にトラップされるという問題があるので、
+初期値を変えた計算を何回か繰り返して結果を確認するか、オプションの
+ベイスンホッピング法 (`scipy.optimize.basinhopping`_) による大域最適化
+(ランダムなホップと ``method`` で選んだ手法による局所最適化を繰り返す方法。
+後述の ``basinhopping`` パラメータを参照) の利用をおすすめします。
 
 
 前準備
@@ -209,4 +214,5 @@ ODAT-SE 固有のキーである ``method``, ``initial_scale_list``,
 リスタート
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Nelder-Mead法による最適値探索はリスタートに対応していません。
+``minsearch`` アルゴリズムはリスタートに対応していません
+(選択した手法や basinhopping の有無によりません)。

--- a/doc/ja/source/algorithm/minsearch.rst
+++ b/doc/ja/source/algorithm/minsearch.rst
@@ -69,7 +69,8 @@ ODAT-SEは、SciPy の ``scipy.optimize.minimize(method="Nelder-Mead")`` 関数�
 最適化手法とそのハイパーパラメータを設定します。
 詳細は `scipy.optimize.minimize`_ のドキュメントを参照してください。
 
-``method`` と ``initial_scale_list`` 以外のパラメータは、そのまま
+ODAT-SE 固有のキーである ``method``, ``initial_scale_list``,
+``basinhopping``(後述)以外のパラメータは、そのまま
 `scipy.optimize.minimize`_ の ``options`` 引数に渡されます。
 選択した手法が受け付けないパラメータ名が指定された場合は、
 最適化を開始する前にエラーで終了します。

--- a/doc/ja/source/algorithm/minsearch.rst
+++ b/doc/ja/source/algorithm/minsearch.rst
@@ -1,11 +1,12 @@
-==========================================
-scipy.optimize による最適化 ``minsearch``
-==========================================
+======================================================
+局所最適化アルゴリズムによる最適値探索 ``minsearch``
+======================================================
 
 .. _scipy.optimize.minimize: https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html
 .. _scipy.optimize.basinhopping: https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.basinhopping.html
 
-``minsearch`` は SciPy の `scipy.optimize.minimize`_ 関数を用いて最適化を行います。
+``minsearch`` は局所最適化アルゴリズムによって最適値探索を行います。
+実装には SciPy の `scipy.optimize.minimize`_ 関数を用いています。
 最適化手法は ``[algorithm.minimize]`` セクションの ``method`` パラメータで選択します。
 デフォルトは `Nelder-Mead 法 <https://en.wikipedia.org/wiki/Nelder%E2%80%93Mead_method>`_
 (a.k.a. downhill simplex 法) で、 `scipy.optimize.minimize`_ が受け付ける

--- a/src/odatse/algorithm/min_search.py
+++ b/src/odatse/algorithm/min_search.py
@@ -231,6 +231,11 @@ class Algorithm(odatse.algorithm.AlgorithmBase):
         # for methods that support it, let scipy keep the search within the
         # region via bounds=. the range check in _f_calc then allows points
         # exactly on the boundary, which such methods evaluate legitimately.
+        # On older scipy where the method predates bounds support (e.g.
+        # Powell < 1.5, COBYLA < 1.11), scipy itself ignores bounds= with a
+        # RuntimeWarning ("Method X cannot handle bounds."); that warning is
+        # not escalated by the OptimizeWarning filter below, and the range
+        # check in _f_calc remains as the inf-penalty safety net.
         use_bounds = self.method.lower() in self._BOUNDS_METHODS
 
         def _f_calc(x_list: np.ndarray, iset) -> float:

--- a/src/odatse/algorithm/min_search.py
+++ b/src/odatse/algorithm/min_search.py
@@ -12,7 +12,7 @@ import warnings
 
 import numpy as np
 import scipy
-from scipy.optimize import minimize, OptimizeResult, OptimizeWarning
+from scipy.optimize import minimize, basinhopping, OptimizeResult, OptimizeWarning
 
 import odatse
 import odatse.domain
@@ -20,6 +20,27 @@ from odatse.util.version import parse_version
 
 if TYPE_CHECKING:
     from mpi4py import MPI
+
+
+class _ClippedRandomDisplacement:
+    """Random displacement for basinhopping, clipped to the search region.
+
+    The default take_step of scipy's basinhopping may propose points outside
+    [min_list, max_list], which would only waste solver evaluations on the
+    inf-penalty. Clipping keeps every hop inside the region. The ``stepsize``
+    attribute is exposed so that basinhopping's adaptive stepsize adjustment
+    keeps working.
+    """
+
+    def __init__(self, rng, stepsize, min_list, max_list):
+        self.rng = rng
+        self.stepsize = stepsize
+        self.min_list = min_list
+        self.max_list = max_list
+
+    def __call__(self, x):
+        x = x + self.rng.uniform(-self.stepsize, self.stepsize, np.shape(x))
+        return np.clip(x, self.min_list, self.max_list)
 
 
 class Algorithm(odatse.algorithm.AlgorithmBase):
@@ -30,6 +51,11 @@ class Algorithm(odatse.algorithm.AlgorithmBase):
     ``[algorithm.minimize]`` section (default: "Nelder-Mead"). All other
     entries of the section except ODAT-SE-specific keys are passed through
     to scipy.optimize.minimize as its ``options`` argument.
+
+    Setting ``basinhopping`` (a boolean, or a ``[algorithm.minimize.basinhopping]``
+    table whose entries are passed to scipy.optimize.basinhopping) switches to
+    global optimization by basin hopping, with the configured method serving
+    as the local minimizer.
     """
 
     # methods for which ODAT-SE passes bounds= to scipy.optimize.minimize.
@@ -39,7 +65,11 @@ class Algorithm(odatse.algorithm.AlgorithmBase):
 
     # keys of [algorithm.minimize] consumed by ODAT-SE itself, i.e. not
     # forwarded to scipy.optimize.minimize as options
-    _ODATSE_KEYS = {"method", "initial_scale_list"}
+    _ODATSE_KEYS = {"method", "initial_scale_list", "basinhopping"}
+
+    # basinhopping arguments managed by ODAT-SE itself; rejected if the user
+    # sets them in [algorithm.minimize.basinhopping]
+    _BH_RESERVED = {"minimizer_kwargs", "take_step", "accept_test", "callback", "seed", "rng"}
 
     # inputs
     label_list: np.ndarray
@@ -51,6 +81,8 @@ class Algorithm(odatse.algorithm.AlgorithmBase):
     # optimization method and its options
     method: str
     minimize_options: dict
+    # None: plain minimize; dict (possibly empty): basinhopping parameters
+    basinhopping_params: Optional[dict]
 
     # hyperparameters of Nelder-Mead
     initial_simplex_list: list[list[float]]
@@ -64,6 +96,7 @@ class Algorithm(odatse.algorithm.AlgorithmBase):
 
     iter_history: list[list[Union[int, float]]]
     fev_history: list[list[Union[int, float]]]
+    hop_history: list[list[Union[int, float]]]
 
     def __init__(
         self,
@@ -108,6 +141,29 @@ class Algorithm(odatse.algorithm.AlgorithmBase):
         self.initial_scale_list = info_minimize.get(
             "initial_scale_list", [0.25] * self.dimension
         )
+
+        # basinhopping = true enables scipy.optimize.basinhopping with its
+        # default parameters; a [algorithm.minimize.basinhopping] table both
+        # enables it and forwards its entries as basinhopping arguments
+        bh = info_minimize.get("basinhopping", False)
+        if bh is False or bh is None:
+            self.basinhopping_params = None
+        elif bh is True:
+            self.basinhopping_params = {}
+        elif isinstance(bh, dict):
+            self.basinhopping_params = dict(bh)
+        else:
+            raise ValueError(
+                "algorithm.minimize.basinhopping must be a boolean or a table, "
+                f"not {type(bh).__name__}"
+            )
+        if self.basinhopping_params is not None:
+            reserved = self._BH_RESERVED & set(self.basinhopping_params)
+            if reserved:
+                raise ValueError(
+                    "algorithm.minimize.basinhopping parameters {} are managed "
+                    "by ODAT-SE and cannot be set in the input file".format(sorted(reserved))
+                )
 
         # forward all remaining entries verbatim to scipy.optimize.minimize
         # as its options argument; unknown option names are detected by scipy
@@ -222,8 +278,9 @@ class Algorithm(odatse.algorithm.AlgorithmBase):
                 fev_history.append([step[0], *x_scaled, y])
             return y
 
+        use_basinhopping = self.basinhopping_params is not None
+
         options = dict(self.minimize_options)
-        options.setdefault("disp", True)
         if self.method.lower() == "nelder-mead":
             # keep the historical defaults of the Nelder-Mead implementation;
             # user-specified values in [algorithm.minimize] take precedence
@@ -231,12 +288,31 @@ class Algorithm(odatse.algorithm.AlgorithmBase):
             options.setdefault("fatol", 0.0001)
             options.setdefault("maxiter", 10000)
             options.setdefault("maxfev", 100000)
-            options.setdefault("initial_simplex", self.initial_simplex_list)
-            options.setdefault("return_all", True)
+            if not use_basinhopping:
+                # a fixed initial simplex makes scipy ignore its x0 argument,
+                # which would restart every basinhopping hop from the same
+                # simplex; only usable for a single local optimization
+                options.setdefault("initial_simplex", self.initial_simplex_list)
+                options.setdefault("return_all", True)
+        if use_basinhopping:
+            # per-hop convergence messages of the local minimizer are noisy;
+            # progress is reported per hop by basinhopping itself
+            options.setdefault("disp", False)
+        else:
+            options.setdefault("disp", True)
 
         minimize_kwargs = {}
         if use_bounds:
             minimize_kwargs["bounds"] = list(zip(min_list, max_list))
+
+        hop_history = []
+
+        def _bh_cb(x, f, accept):
+            """
+            Per-hop callback function for scipy.optimize.basinhopping.
+            """
+            print("hop: x={}, fun={}, accept={}".format(x, f, accept))
+            hop_history.append([len(hop_history), *x, f, int(accept)])
 
         time_sta = time.perf_counter()
         try:
@@ -248,15 +324,47 @@ class Algorithm(odatse.algorithm.AlgorithmBase):
                 warnings.filterwarnings(
                     "error", message="Unknown solver options", category=OptimizeWarning
                 )
-                optres = minimize(
-                    _f_calc,
-                    self.initial_list,
-                    method=self.method,
-                    args=(0,),
-                    options=options,
-                    callback=_cb,
-                    **minimize_kwargs,
-                )
+                if use_basinhopping:
+                    bh_params = dict(self.basinhopping_params)
+                    bh_params.setdefault("disp", True)
+                    take_step = _ClippedRandomDisplacement(
+                        self.rng, bh_params.pop("stepsize", 0.5), min_list, max_list
+                    )
+                    try:
+                        optres = basinhopping(
+                            _f_calc,
+                            self.initial_list,
+                            minimizer_kwargs={
+                                "method": self.method,
+                                "args": (0,),
+                                "options": options,
+                                "callback": _cb,
+                                **minimize_kwargs,
+                            },
+                            take_step=take_step,
+                            callback=_bh_cb,
+                            # self.rng is a RandomState; the deprecated seed
+                            # path accepts it on scipy >= 1.15 while rng= does
+                            # not, and older scipy has only seed
+                            seed=self.rng,
+                            **bh_params,
+                        )
+                    except TypeError as e:
+                        raise RuntimeError(
+                            f"{e}: check the [algorithm.minimize.basinhopping] "
+                            f"section of the input file against the arguments "
+                            f"accepted by scipy.optimize.basinhopping"
+                        ) from e
+                else:
+                    optres = minimize(
+                        _f_calc,
+                        self.initial_list,
+                        method=self.method,
+                        args=(0,),
+                        options=options,
+                        callback=_cb,
+                        **minimize_kwargs,
+                    )
         except OptimizeWarning as w:
             raise RuntimeError(
                 f"{w}: check the [algorithm.minimize] section of the input file "
@@ -274,6 +382,7 @@ class Algorithm(odatse.algorithm.AlgorithmBase):
 
         self.iter_history = iter_history
         self.fev_history = fev_history
+        self.hop_history = hop_history
 
         self._output_results()
 
@@ -310,6 +419,12 @@ class Algorithm(odatse.algorithm.AlgorithmBase):
             fp.write("#No " + " ".join(label_list) + "\n")
             for i, v in enumerate(self.fev_history):
                 fp.write(" ".join(map(str,v)) + "\n")
+
+        if self.hop_history:
+            with open("BasinHoppingData.txt", "w") as fp:
+                fp.write("#hop " + " ".join(label_list) + " R-factor accept\n")
+                for v in self.hop_history:
+                    fp.write(" ".join(map(str, v)) + "\n")
 
         with open("res.txt", "w") as fp:
             fp.write(f"fx = {self.fopt}\n")

--- a/src/odatse/algorithm/min_search.py
+++ b/src/odatse/algorithm/min_search.py
@@ -7,6 +7,7 @@
 # If a copy of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from typing import Union, Optional, TYPE_CHECKING
+import inspect
 import time
 import warnings
 
@@ -163,6 +164,20 @@ class Algorithm(odatse.algorithm.AlgorithmBase):
                 raise ValueError(
                     "algorithm.minimize.basinhopping parameters {} are managed "
                     "by ODAT-SE and cannot be set in the input file".format(sorted(reserved))
+                )
+            # validate the argument names against the signature of the
+            # installed scipy before anything runs, instead of catching
+            # TypeError around the optimizer call: a TypeError raised at
+            # runtime (by the solver, a callback, ...) must not be
+            # misreported as an input-file mistake
+            accepted = set(inspect.signature(basinhopping).parameters)
+            unknown = set(self.basinhopping_params) - accepted
+            if unknown:
+                raise ValueError(
+                    "algorithm.minimize.basinhopping parameters {} are not accepted "
+                    "by scipy.optimize.basinhopping of the installed scipy version; "
+                    "accepted arguments are {}".format(
+                        sorted(unknown), sorted(accepted - {"func", "x0"} - self._BH_RESERVED))
                 )
 
         # forward all remaining entries verbatim to scipy.optimize.minimize
@@ -330,36 +345,32 @@ class Algorithm(odatse.algorithm.AlgorithmBase):
                     "error", message="Unknown solver options", category=OptimizeWarning
                 )
                 if use_basinhopping:
+                    # argument names were validated against the basinhopping
+                    # signature in __init__, so a TypeError here is a genuine
+                    # runtime failure and propagates unchanged
                     bh_params = dict(self.basinhopping_params)
                     bh_params.setdefault("disp", True)
                     take_step = _ClippedRandomDisplacement(
                         self.rng, bh_params.pop("stepsize", 0.5), min_list, max_list
                     )
-                    try:
-                        optres = basinhopping(
-                            _f_calc,
-                            self.initial_list,
-                            minimizer_kwargs={
-                                "method": self.method,
-                                "args": (0,),
-                                "options": options,
-                                "callback": _cb,
-                                **minimize_kwargs,
-                            },
-                            take_step=take_step,
-                            callback=_bh_cb,
-                            # self.rng is a RandomState; the deprecated seed
-                            # path accepts it on scipy >= 1.15 while rng= does
-                            # not, and older scipy has only seed
-                            seed=self.rng,
-                            **bh_params,
-                        )
-                    except TypeError as e:
-                        raise RuntimeError(
-                            f"{e}: check the [algorithm.minimize.basinhopping] "
-                            f"section of the input file against the arguments "
-                            f"accepted by scipy.optimize.basinhopping"
-                        ) from e
+                    optres = basinhopping(
+                        _f_calc,
+                        self.initial_list,
+                        minimizer_kwargs={
+                            "method": self.method,
+                            "args": (0,),
+                            "options": options,
+                            "callback": _cb,
+                            **minimize_kwargs,
+                        },
+                        take_step=take_step,
+                        callback=_bh_cb,
+                        # self.rng is a RandomState; the deprecated seed
+                        # path accepts it on scipy >= 1.15 while rng= does
+                        # not, and older scipy has only seed
+                        seed=self.rng,
+                        **bh_params,
+                    )
                 else:
                     optres = minimize(
                         _f_calc,

--- a/src/odatse/algorithm/min_search.py
+++ b/src/odatse/algorithm/min_search.py
@@ -8,10 +8,11 @@
 
 from typing import Union, Optional, TYPE_CHECKING
 import time
+import warnings
 
 import numpy as np
 import scipy
-from scipy.optimize import minimize
+from scipy.optimize import minimize, OptimizeResult, OptimizeWarning
 
 import odatse
 import odatse.domain
@@ -23,8 +24,22 @@ if TYPE_CHECKING:
 
 class Algorithm(odatse.algorithm.AlgorithmBase):
     """
-    Algorithm class for performing minimization using the Nelder-Mead method.
+    Algorithm class for performing minimization using scipy.optimize.minimize.
+
+    The optimization method is selected by the ``method`` parameter in the
+    ``[algorithm.minimize]`` section (default: "Nelder-Mead"). All other
+    entries of the section except ODAT-SE-specific keys are passed through
+    to scipy.optimize.minimize as its ``options`` argument.
     """
+
+    # methods for which ODAT-SE passes bounds= to scipy.optimize.minimize.
+    # Nelder-Mead is deliberately excluded to keep the legacy behavior of
+    # returning +inf for out-of-range points unchanged.
+    _BOUNDS_METHODS = {"powell", "l-bfgs-b", "tnc", "slsqp", "trust-constr", "cobyla", "cobyqa"}
+
+    # keys of [algorithm.minimize] consumed by ODAT-SE itself, i.e. not
+    # forwarded to scipy.optimize.minimize as options
+    _ODATSE_KEYS = {"method", "initial_scale_list"}
 
     # inputs
     label_list: np.ndarray
@@ -33,17 +48,19 @@ class Algorithm(odatse.algorithm.AlgorithmBase):
     max_list: np.ndarray
     unit_list: np.ndarray
 
+    # optimization method and its options
+    method: str
+    minimize_options: dict
+
     # hyperparameters of Nelder-Mead
     initial_simplex_list: list[list[float]]
-    xtol: float
-    ftol: float
 
     # results
     xopt: np.ndarray
     fopt: float
-    itera: int
-    funcalls: int
-    allvecs: list[np.ndarray]
+    itera: Optional[int]
+    funcalls: Optional[int]
+    allvecs: Optional[list[np.ndarray]]
 
     iter_history: list[list[Union[int, float]]]
     fev_history: list[list[Union[int, float]]]
@@ -87,13 +104,17 @@ class Algorithm(odatse.algorithm.AlgorithmBase):
             self.initial_list = []
 
         info_minimize = info.algorithm.get("minimize", {})
+        self.method = str(info_minimize.get("method", "Nelder-Mead"))
         self.initial_scale_list = info_minimize.get(
             "initial_scale_list", [0.25] * self.dimension
         )
-        self.xtol = info_minimize.get("xatol", 0.0001)
-        self.ftol = info_minimize.get("fatol", 0.0001)
-        self.maxiter = info_minimize.get("maxiter", 10000)
-        self.maxfev = info_minimize.get("maxfev", 100000)
+
+        # forward all remaining entries verbatim to scipy.optimize.minimize
+        # as its options argument; unknown option names are detected by scipy
+        # and turned into an error in _run() before the optimization starts
+        self.minimize_options = {
+            k: v for k, v in info_minimize.items() if k not in self._ODATSE_KEYS
+        }
 
         self._show_parameters()
 
@@ -128,9 +149,18 @@ class Algorithm(odatse.algorithm.AlgorithmBase):
             def _cb(intermediate_result):
                 """
                 Callback function for scipy.optimize.minimize.
+
+                The parameter must be named intermediate_result so that scipy
+                passes an OptimizeResult where supported. Methods that do not
+                support the new-style callback (e.g. COBYLA, SLSQP, TNC) still
+                pass the raw parameter vector, so handle both.
                 """
-                x = intermediate_result.x
-                fun = intermediate_result.fun
+                if isinstance(intermediate_result, OptimizeResult):
+                    x = intermediate_result.x
+                    fun = intermediate_result.fun
+                else:
+                    x = intermediate_result
+                    fun = _f_calc(x, 1)
                 print("eval: x={}, fun={}".format(x, fun))
                 iter_history.append([*x, fun])
         else:
@@ -141,6 +171,11 @@ class Algorithm(odatse.algorithm.AlgorithmBase):
                 fun = _f_calc(x, 1)
                 print("eval: x={}, fun={}".format(x, fun))
                 iter_history.append([*x, fun])
+
+        # for methods that support it, let scipy keep the search within the
+        # region via bounds=. the range check in _f_calc then allows points
+        # exactly on the boundary, which such methods evaluate legitimately.
+        use_bounds = self.method.lower() in self._BOUNDS_METHODS
 
         def _f_calc(x_list: np.ndarray, iset) -> float:
             """
@@ -158,9 +193,12 @@ class Algorithm(odatse.algorithm.AlgorithmBase):
             float
                 Objective function value.
             """
-            # check if within region -> boundary option in minimize
-            # note: 'bounds' option supported in scipy >= 1.7.0
-            in_range = np.all((min_list < x_list) & (x_list < max_list))
+            # check if within region; kept as a safety net even when bounds=
+            # is passed to minimize
+            if use_bounds:
+                in_range = np.all((min_list <= x_list) & (x_list <= max_list))
+            else:
+                in_range = np.all((min_list < x_list) & (x_list < max_list))
             if not in_range:
                 print("Warning: out of range: {}".format(x_list))
                 return float("inf")
@@ -184,30 +222,53 @@ class Algorithm(odatse.algorithm.AlgorithmBase):
                 fev_history.append([step[0], *x_scaled, y])
             return y
 
+        options = dict(self.minimize_options)
+        options.setdefault("disp", True)
+        if self.method.lower() == "nelder-mead":
+            # keep the historical defaults of the Nelder-Mead implementation;
+            # user-specified values in [algorithm.minimize] take precedence
+            options.setdefault("xatol", 0.0001)
+            options.setdefault("fatol", 0.0001)
+            options.setdefault("maxiter", 10000)
+            options.setdefault("maxfev", 100000)
+            options.setdefault("initial_simplex", self.initial_simplex_list)
+            options.setdefault("return_all", True)
+
+        minimize_kwargs = {}
+        if use_bounds:
+            minimize_kwargs["bounds"] = list(zip(min_list, max_list))
+
         time_sta = time.perf_counter()
-        optres = minimize(
-            _f_calc,
-            self.initial_list,
-            method="Nelder-Mead",
-            args=(0,),
-            # bounds=[(a,b) for a,b in zip(min_list, max_list)],
-            options={
-                "xatol": self.xtol,
-                "fatol": self.ftol,
-                "return_all": True,
-                "disp": True,
-                "maxiter": self.maxiter,
-                "maxfev": self.maxfev,
-                "initial_simplex": self.initial_simplex_list,
-            },
-            callback=_cb,
-        )
+        try:
+            with warnings.catch_warnings():
+                # scipy only warns on option names the method does not accept
+                # and silently ignores them; promote the warning to an error
+                # so that e.g. a misspelled tolerance aborts immediately
+                # instead of running a lengthy optimization with defaults
+                warnings.filterwarnings(
+                    "error", message="Unknown solver options", category=OptimizeWarning
+                )
+                optres = minimize(
+                    _f_calc,
+                    self.initial_list,
+                    method=self.method,
+                    args=(0,),
+                    options=options,
+                    callback=_cb,
+                    **minimize_kwargs,
+                )
+        except OptimizeWarning as w:
+            raise RuntimeError(
+                f"{w}: check the [algorithm.minimize] section of the input file "
+                f"against the options accepted by scipy.optimize.minimize "
+                f"for method '{self.method}'"
+            ) from w
 
         self.xopt = optres.x
         self.fopt = optres.fun
-        self.itera = optres.nit
-        self.funcalls = optres.nfev
-        self.allvecs = optres.allvecs
+        self.itera = getattr(optres, "nit", None)
+        self.funcalls = getattr(optres, "nfev", None)
+        self.allvecs = getattr(optres, "allvecs", None)
         time_end = time.perf_counter()
         self.timer["run"]["min_search"] = time_end - time_sta
 
@@ -223,6 +284,9 @@ class Algorithm(odatse.algorithm.AlgorithmBase):
     def _prepare(self):
         """
         Prepare the initial simplex for the Nelder-Mead algorithm.
+
+        The simplex is only passed to scipy when method is Nelder-Mead;
+        for other methods it is built but unused.
         """
         # make initial simplex
         #   [ v0, v0+a_1*e_1, v0+a_2*e_2, ... v0+a_d*e_d ]
@@ -251,8 +315,11 @@ class Algorithm(odatse.algorithm.AlgorithmBase):
             fp.write(f"fx = {self.fopt}\n")
             for x, y in zip(label_list, self.xopt):
                 fp.write(f"{x} = {y}\n")
-            fp.write(f"iterations = {self.itera}\n")
-            fp.write(f"function_evaluations = {self.funcalls}\n")
+            # some methods (e.g. COBYLA) do not report these quantities
+            if self.itera is not None:
+                fp.write(f"iterations = {self.itera}\n")
+            if self.funcalls is not None:
+                fp.write(f"function_evaluations = {self.funcalls}\n")
 
     def _post(self):
         """

--- a/tests/unit/test_min_search.py
+++ b/tests/unit/test_min_search.py
@@ -9,7 +9,7 @@ import odatse.solver.function
 import odatse.algorithm.min_search as min_search
 
 
-def _run_minsearch(workdir, unit_list, record):
+def _run_minsearch(workdir, unit_list, record, minimize=None):
     def fn(x):
         record.append(np.array(x, copy=True))
         return float(np.sum(x * x))
@@ -25,7 +25,7 @@ def _run_minsearch(workdir, unit_list, record):
                 "initial_list": [2.0, 2.0],
                 "unit_list": unit_list,
             },
-            "minimize": {"maxiter": 3, "maxfev": 10},
+            "minimize": {"maxiter": 3, "maxfev": 10} if minimize is None else minimize,
         },
         "solver": {"name": "function"},
         "runner": {},
@@ -39,7 +39,7 @@ def _run_minsearch(workdir, unit_list, record):
     # ranks draw a random initial point, so capture this rank's actual one
     x0 = np.array(alg.initial_list, dtype=float, copy=True)
     alg.main()
-    return x0
+    return x0, alg
 
 
 def test_initial_evaluation_uses_unit_scaling(tmp_path, monkeypatch):
@@ -48,7 +48,7 @@ def test_initial_evaluation_uses_unit_scaling(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     record = []
     unit_list = [2.0, 2.0]
-    x0 = _run_minsearch(tmp_path, unit_list=unit_list, record=record)
+    x0, _ = _run_minsearch(tmp_path, unit_list=unit_list, record=record)
     # the initial point must arrive at the solver divided by unit_list
     # (e.g. [2, 2] -> [1, 1]); the unfixed code submitted it unscaled
     np.testing.assert_allclose(record[0], x0 / np.array(unit_list))
@@ -62,3 +62,79 @@ def test_run_with_prerelease_scipy_version(tmp_path, monkeypatch):
     record = []
     _run_minsearch(tmp_path, unit_list=[1.0, 1.0], record=record)
     assert len(record) > 0
+
+
+def test_method_defaults_to_nelder_mead(tmp_path, monkeypatch):
+    """Without [algorithm.minimize] method, the historical Nelder-Mead
+    behavior (including its default tolerances) must be preserved."""
+    monkeypatch.chdir(tmp_path)
+    record = []
+    x0, alg = _run_minsearch(tmp_path, unit_list=[1.0, 1.0], record=record,
+                             minimize={"maxiter": 200, "maxfev": 1000})
+    assert alg.method == "Nelder-Mead"
+    # ODAT-SE-specific keys must not leak into the scipy options
+    assert set(alg.minimize_options) == {"maxiter", "maxfev"}
+    np.testing.assert_allclose(alg.xopt, [0.0, 0.0], atol=1e-3)
+    assert alg.itera is not None and alg.funcalls is not None
+    # return_all is enabled by default for Nelder-Mead
+    assert alg.allvecs is not None
+
+
+def test_method_powell_converges(tmp_path, monkeypatch):
+    """method = "Powell" runs through scipy.optimize.minimize and converges;
+    bounds are handled by scipy for this method."""
+    monkeypatch.chdir(tmp_path)
+    record = []
+    _, alg = _run_minsearch(tmp_path, unit_list=[1.0, 1.0], record=record,
+                            minimize={"method": "Powell", "maxiter": 100, "maxfev": 1000})
+    assert alg.method == "Powell"
+    assert "method" not in alg.minimize_options
+    np.testing.assert_allclose(alg.xopt, [0.0, 0.0], atol=1e-3)
+    # initial_simplex/return_all are Nelder-Mead defaults and must not be
+    # injected for other methods
+    assert alg.allvecs is None
+
+
+def test_method_cobyla_without_nit(tmp_path, monkeypatch):
+    """COBYLA's OptimizeResult carries no nit/allvecs attribute; the result
+    handling and res.txt output must not crash on their absence."""
+    monkeypatch.chdir(tmp_path)
+    record = []
+    x0, alg = _run_minsearch(tmp_path, unit_list=[1.0, 1.0], record=record,
+                             minimize={"method": "COBYLA", "maxiter": 200})
+    assert alg.fopt < float(np.sum(x0 * x0))
+    # res.txt files are written into output/<rank>/ (and the cwd by _post);
+    # none of them may contain a literal "None" from missing nit/nfev
+    res_files = list(tmp_path.glob("**/res.txt"))
+    assert res_files
+    for f in res_files:
+        assert "None" not in f.read_text()
+
+
+def test_unknown_option_raises(tmp_path, monkeypatch):
+    """An option name the selected method does not accept must abort before
+    the optimization instead of being silently ignored by scipy."""
+    monkeypatch.chdir(tmp_path)
+    record = []
+    with pytest.raises(RuntimeError, match="Unknown solver options"):
+        _run_minsearch(tmp_path, unit_list=[1.0, 1.0], record=record,
+                       minimize={"maxiter": 10, "no_such_option": 42})
+
+
+def test_option_valid_for_other_method_raises(tmp_path, monkeypatch):
+    """An option that belongs to a different method (gtol is for gradient
+    methods, not Nelder-Mead) must abort as well."""
+    monkeypatch.chdir(tmp_path)
+    record = []
+    with pytest.raises(RuntimeError, match="Unknown solver options"):
+        _run_minsearch(tmp_path, unit_list=[1.0, 1.0], record=record,
+                       minimize={"gtol": 1e-5})
+
+
+def test_invalid_method_raises(tmp_path, monkeypatch):
+    """A method name scipy does not know must raise, not run."""
+    monkeypatch.chdir(tmp_path)
+    record = []
+    with pytest.raises(ValueError):
+        _run_minsearch(tmp_path, unit_list=[1.0, 1.0], record=record,
+                       minimize={"method": "no-such-method"})

--- a/tests/unit/test_min_search.py
+++ b/tests/unit/test_min_search.py
@@ -198,12 +198,38 @@ def test_basinhopping_hops_stay_in_range(tmp_path, monkeypatch):
 
 def test_basinhopping_unknown_param_raises(tmp_path, monkeypatch):
     """An argument scipy.optimize.basinhopping does not accept must abort
-    with a message pointing at the input file section."""
+    at construction time, before any solver evaluation, with a message
+    pointing at the input file section (issue #76)."""
     monkeypatch.chdir(tmp_path)
     record = []
-    with pytest.raises(RuntimeError, match="basinhopping"):
+    with pytest.raises(ValueError, match="basinhopping"):
         _run_minsearch(tmp_path, unit_list=[1.0, 1.0], record=record,
-                       minimize={"basinhopping": {"no_such_param": 1}})
+                       minimize={"basinhopping": {"no_such_param": 1}},
+                       run=False)
+    # nothing was evaluated
+    assert record == []
+
+
+def test_basinhopping_runtime_typeerror_propagates(tmp_path, monkeypatch):
+    """A TypeError raised by the objective function during the basinhopping
+    run must propagate unchanged instead of being misreported as an
+    input-configuration error (issue #76)."""
+    monkeypatch.chdir(tmp_path)
+    record = []
+    calls = [0]
+
+    def broken(x):
+        calls[0] += 1
+        if calls[0] > 5:
+            raise TypeError("broken objective")
+        record.append(np.array(x, copy=True))
+        return float(np.sum(x * x))
+
+    with pytest.raises(TypeError, match="broken objective"):
+        _run_minsearch(tmp_path, unit_list=[1.0, 1.0], record=record,
+                       fn=broken,
+                       minimize={"maxiter": 100, "maxfev": 500,
+                                 "basinhopping": {"niter": 5}})
 
 
 def test_basinhopping_reserved_param_raises(tmp_path, monkeypatch):

--- a/tests/unit/test_min_search.py
+++ b/tests/unit/test_min_search.py
@@ -9,10 +9,11 @@ import odatse.solver.function
 import odatse.algorithm.min_search as min_search
 
 
-def _run_minsearch(workdir, unit_list, record, minimize=None):
-    def fn(x):
-        record.append(np.array(x, copy=True))
-        return float(np.sum(x * x))
+def _run_minsearch(workdir, unit_list, record, minimize=None, run=True, fn=None):
+    if fn is None:
+        def fn(x):
+            record.append(np.array(x, copy=True))
+            return float(np.sum(x * x))
 
     inp = {
         "base": {"dimension": 2, "output_dir": str(workdir / "output")},
@@ -38,7 +39,8 @@ def _run_minsearch(workdir, unit_list, record, minimize=None):
     # under mpirun only walker 0 gets the configured initial_list; the other
     # ranks draw a random initial point, so capture this rank's actual one
     x0 = np.array(alg.initial_list, dtype=float, copy=True)
-    alg.main()
+    if run:
+        alg.main()
     return x0, alg
 
 
@@ -138,3 +140,78 @@ def test_invalid_method_raises(tmp_path, monkeypatch):
     with pytest.raises(ValueError):
         _run_minsearch(tmp_path, unit_list=[1.0, 1.0], record=record,
                        minimize={"method": "no-such-method"})
+
+
+def test_basinhopping_converges(tmp_path, monkeypatch):
+    """basinhopping with a Nelder-Mead local minimizer finds the global
+    minimum of a double-well function whose nearest local minimum from the
+    initial point is not the global one."""
+    monkeypatch.chdir(tmp_path)
+    record = []
+
+    def double_well(x):
+        # wells at x0 = +/-2 with f(+2) = -1 (local) and f(-2) = -3 (global);
+        # the initial point [2, 2] sits in the +2 well
+        record.append(np.array(x, copy=True))
+        return float(((x[0] ** 2 - 4) ** 2) / 8.0 + 0.5 * x[0] - 2.0 + x[1] ** 2)
+
+    x0, alg = _run_minsearch(
+        tmp_path, unit_list=[1.0, 1.0], record=record, fn=double_well,
+        minimize={"maxiter": 500, "maxfev": 2000,
+                  "basinhopping": {"niter": 20, "stepsize": 2.0, "T": 1.0}})
+    assert alg.basinhopping_params == {"niter": 20, "stepsize": 2.0, "T": 1.0}
+    # basinhopping keys must not leak into the minimize options
+    assert set(alg.minimize_options) == {"maxiter", "maxfev"}
+    # global minimum is near x = (-2 - eps, 0), f ~ -3; the +2 well only
+    # reaches f ~ -1, so f < -2 shows the hop out of the initial well
+    assert alg.fopt < -2.0
+    # per-hop history is recorded and written out; scipy runs niter + 1
+    # local minimizations (the extra one from the initial point)
+    assert len(alg.hop_history) == 21
+    assert list(tmp_path.glob("**/BasinHoppingData.txt"))
+
+
+def test_basinhopping_flag_true(tmp_path, monkeypatch):
+    """basinhopping = true (bare boolean) enables basinhopping with scipy
+    default parameters."""
+    monkeypatch.chdir(tmp_path)
+    record = []
+    _, alg = _run_minsearch(tmp_path, unit_list=[1.0, 1.0], record=record,
+                            minimize={"basinhopping": True}, run=False)
+    assert alg.basinhopping_params == {}
+    assert "basinhopping" not in alg.minimize_options
+
+
+def test_basinhopping_hops_stay_in_range(tmp_path, monkeypatch):
+    """Even with a stepsize far larger than the search region, hops are
+    clipped into [min_list, max_list]."""
+    monkeypatch.chdir(tmp_path)
+    record = []
+    _, alg = _run_minsearch(
+        tmp_path, unit_list=[1.0, 1.0], record=record,
+        minimize={"maxiter": 200, "maxfev": 1000,
+                  "basinhopping": {"niter": 5, "stepsize": 100.0}})
+    for hop in alg.hop_history:
+        x = np.array(hop[1:3])
+        assert np.all((x >= alg.min_list) & (x <= alg.max_list))
+
+
+def test_basinhopping_unknown_param_raises(tmp_path, monkeypatch):
+    """An argument scipy.optimize.basinhopping does not accept must abort
+    with a message pointing at the input file section."""
+    monkeypatch.chdir(tmp_path)
+    record = []
+    with pytest.raises(RuntimeError, match="basinhopping"):
+        _run_minsearch(tmp_path, unit_list=[1.0, 1.0], record=record,
+                       minimize={"basinhopping": {"no_such_param": 1}})
+
+
+def test_basinhopping_reserved_param_raises(tmp_path, monkeypatch):
+    """Arguments managed by ODAT-SE (take_step, seed, ...) cannot be set
+    from the input file."""
+    monkeypatch.chdir(tmp_path)
+    record = []
+    with pytest.raises(ValueError, match="managed by ODAT-SE"):
+        _run_minsearch(tmp_path, unit_list=[1.0, 1.0], record=record,
+                       minimize={"basinhopping": {"take_step": "foo"}},
+                       run=False)


### PR DESCRIPTION
## Summary

The `minsearch` algorithm hard-coded the Nelder-Mead method, although it is
in fact a wrapper around `scipy.optimize.minimize`. This PR generalizes it in
three steps, keeping full backward compatibility:

1. **Method selection**: a new `method` parameter in `[algorithm.minimize]`
   selects the optimization method of `scipy.optimize.minimize`
   (default: `"Nelder-Mead"`).
2. **Option pass-through**: all entries of `[algorithm.minimize]` other than
   ODAT-SE-specific keys are passed verbatim to the `options` argument of
   `scipy.optimize.minimize`. The legacy keys (`xatol`, `fatol`, `maxiter`,
   `maxfev`) already coincide with scipy option names, so existing input
   files work unchanged.
3. **Global optimization via basin hopping**: setting `basinhopping = true`
   or defining a `[algorithm.minimize.basinhopping]` sub-table switches to
   `scipy.optimize.basinhopping`, with the configured `method` serving as
   the local minimizer of each hop.

```toml
[algorithm.minimize]
method = "Nelder-Mead"

[algorithm.minimize.basinhopping]
niter = 50
stepsize = 0.5
```

## Design notes

- **Fail-fast on unknown options**: scipy only warns
  (`OptimizeWarning: Unknown solver options`) and silently ignores option
  names the selected method does not accept. Since each function evaluation
  is an expensive solver run, the warning is promoted to an error so that
  e.g. a misspelled tolerance aborts before the optimization starts, with a
  message pointing at the input file section. The same policy applies to the
  basinhopping sub-table (unknown arguments raise before the run).
- **Bounds**: `min_list` / `max_list` are passed as the `bounds` argument for
  methods that support it (Powell, L-BFGS-B, TNC, SLSQP, trust-constr,
  COBYLA, COBYQA). Nelder-Mead deliberately keeps the legacy behavior of
  returning `inf` for out-of-range points, so existing results are unchanged.
- **Nelder-Mead defaults preserved**: the historical defaults (`xatol=1e-4`,
  `fatol=1e-4`, `maxiter=10000`, `maxfev=100000`, initial simplex from
  `initial_scale_list`, `return_all`) are applied only for Nelder-Mead and
  only when not overridden by the user.
- **No initial simplex under basinhopping**: scipy's Nelder-Mead ignores `x0`
  when `initial_simplex` is given, which would restart every hop from the
  same simplex; the simplex (and `initial_scale_list`) is therefore not used
  when basinhopping is enabled.
- **Clipped hops**: random hops are clipped into `[min_list, max_list]` by a
  custom `take_step` that exposes the `stepsize` attribute, remaining
  compatible with scipy's adaptive stepsize adjustment.
- **Callback compatibility**: even on recent scipy (1.15.x), COBYLA / SLSQP /
  TNC still invoke the callback with a raw `ndarray` instead of an
  `OptimizeResult`; this is handled by an `isinstance` check in addition to
  the existing scipy version gate.
- **Defensive result handling**: `nit` / `nfev` / `allvecs` are absent for
  some methods (e.g. COBYLA has no `nit`); they are fetched with `getattr`
  and written to `res.txt` only when available.
- **Reproducibility**: basinhopping receives `seed=self.rng`. The legacy
  `np.random.RandomState` is not accepted by the new `rng=` argument of
  scipy >= 1.15 (SPEC 7), while the `seed=` path works across all supported
  scipy versions without warnings.
- **Per-hop output**: hop history (hop number, variables, function value,
  acceptance flag) is written to a new `BasinHoppingData.txt`.
- Under MPI, each rank runs an independent (multistart) optimization from its
  own initial point, as before; this now composes with basinhopping.

## scipy version compatibility

The package requirement is `scipy>=1,<2`. Features degrade explicitly, never
silently: unsupported method names (`trust-constr` < 1.1, `COBYQA` < 1.14)
raise immediately; bounds unsupported by old scipy (Powell < 1.5,
COBYLA < 1.11) fall back to the inf-penalty safety net with a warning;
the new-style callback falls back to the old style below 1.11.

## Testing

- New unit tests in `tests/unit/test_min_search.py`: default method,
  Powell/COBYLA convergence and completion, unknown option / unknown method /
  reserved argument errors, basin hopping escaping a non-global well of a
  double-well function, and hop clipping with an oversized stepsize.
- `pytest tests/unit/`: 140 passed (also under `mpirun -n 2`).
- Integration test `tests/minsearch/do.sh`: output is bit-identical to
  `ref.txt`, confirming the legacy Nelder-Mead path is unchanged.
- Documentation (ja/en) updated: `method`, pass-through semantics,
  `basinhopping` sub-table with example, `BasinHoppingData.txt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)