### PR TITLE
fix(cli): separate CLI entry point from odatse.main and fix exit status

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ all = [
 Repository = "https://github.com/issp-center-dev/ODAT-SE"
 
 [project.scripts]
-odatse = "odatse:main"
+odatse = "odatse:cli"
 odatse_neighborlist = "odatse.util.neighborlist:main"
 odatse_extract_combined = "odatse.scripts.extract_combined:main"
 odatse_plt_1D_histogram = "odatse.scripts.plt_1D_histogram:main"

--- a/src/odatse/__init__.py
+++ b/src/odatse/__init__.py
@@ -13,7 +13,7 @@ from ._info import Info
 from . import solver
 from ._runner import Runner
 from . import algorithm
-from ._main import main
+from ._main import main, cli
 from ._initialize import initialize
 
 __version__ = "3.3-dev"

--- a/src/odatse/__main__.py
+++ b/src/odatse/__main__.py
@@ -6,7 +6,9 @@
 # This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
 # If a copy of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import sys
+
 import odatse
 
 if __name__ == "__main__":
-    odatse.main()
+    sys.exit(odatse.cli())

--- a/src/odatse/_main.py
+++ b/src/odatse/_main.py
@@ -39,18 +39,23 @@ def choose_solver(info):
     raise exception.InputError(f"Unknown solver ({solvername})")
 
 
-def main(argv: Optional[Sequence[str]] = None):
+def main(argv: Optional[Sequence[str]] = None) -> dict:
     """
-    Command-line entry point for the data-analysis software.
+    Run an analysis specified by command-line style arguments.
 
-    Parses command-line arguments, loads the input file, selects the algorithm
-    and solver, and executes the analysis.
+    Parses the arguments, loads the input file, selects the algorithm and
+    solver, executes the analysis, and returns the result of
+    ``Algorithm.main()`` so that programmatic callers can use it as
+    ``result = odatse.main(argv)``.
 
     This is the top-level boundary: user-facing errors
     (``odatse.exception.Error``) are reported and converted to a non-zero exit
-    status. To handle these as exceptions instead, compose the lower-level API
-    (``odatse.initialize`` / ``odatse.algorithm.choose_algorithm`` /
-    ``Algorithm``) directly.
+    status via ``sys.exit(1)``. To handle these as exceptions instead, compose
+    the lower-level API (``odatse.initialize`` /
+    ``odatse.algorithm.choose_algorithm`` / ``Algorithm``) directly.
+
+    Note: do not use this function as a console-script entry point; use
+    ``cli()``, which converts the result to an exit status.
     """
     try:
         info, run_mode = odatse.initialize(argv)
@@ -72,3 +77,16 @@ def main(argv: Optional[Sequence[str]] = None):
         elif odatse.mpi.rank() == 0:
             print(f"ERROR: {e}", file=sys.stderr)
         sys.exit(1)
+
+
+def cli(argv: Optional[Sequence[str]] = None) -> int:
+    """
+    Console-script entry point for the ``odatse`` command.
+
+    Runs :func:`main` and returns exit status 0 on success, discarding the
+    result object (``sys.exit()`` would interpret a non-integer return value
+    as a failure). Errors are reported inside :func:`main` and terminate the
+    process with exit status 1.
+    """
+    main(argv)
+    return 0

--- a/src/odatse_main.py
+++ b/src/odatse_main.py
@@ -8,6 +8,8 @@
 
 if __name__ == "__main__":
     # sys.path[0] is this directory (this project's src)
+    import sys
+
     import odatse
 
-    odatse.main()
+    sys.exit(odatse.cli())


### PR DESCRIPTION
## Overview

Every successful `odatse input.toml` run ended with **exit code 1** and
a stray result dict printed to stderr:

```console
$ odatse input.toml
...
end of run
{'x': array([2.99996696, 1.99999734]), 'fx': 4.2278370361994904e-08, 'x0': array([0, 0])}
$ echo $?
1
```

`odatse.main()` returns the result dict of `Algorithm.main()`, and the
console script generated from `[project.scripts]` wraps the entry point
in `sys.exit()`, which treats a non-integer argument as a failure:
it prints the argument to stderr and exits with status 1. The two other
launch paths (`python3 -m odatse` and `python3 src/odatse_main.py`)
discarded the result and exited 0, so the three paths disagreed.
This breaks exit-status checks in shell scripts and CI pipelines,
which see every successful run as a failure.

## Design

Rather than making `main()` return an exit code, keep the programmatic
API and the CLI as distinct contracts:

- **`odatse.main(argv) -> dict`** keeps returning the result of
  `Algorithm.main()` and is now documented as the programmatic entry
  point (`result = odatse.main(argv)`). User-facing errors are still
  reported inside `main()` (MPI-rank aware) and terminate with
  `sys.exit(1)`.
- **`odatse.cli(argv) -> int`** is a new small wrapper that runs
  `main()`, discards the result, and returns exit status 0.
- **All three launchers share the wrapper**:

  | Launch path | Entry |
  |---|---|
  | `odatse` command | `[project.scripts] odatse = "odatse:cli"` |
  | `python3 -m odatse` | `__main__.py`: `sys.exit(odatse.cli())` |
  | `python3 src/odatse_main.py` | `sys.exit(odatse.cli())` |

  making the exit-status behavior explicit and identical everywhere.

## Compatibility

- No in-repo caller used the return value of `odatse.main()` (verified
  across `src/`, `tests/`, and `doc/`); external callers that did are
  unaffected, since `main()` keeps returning the result dict.
- The console-script target changes from `odatse:main` to
  `odatse:cli`; the generated `odatse` command is updated on
  (re)installation.

## Tests

- All three launch paths: exit 0 on success with no dict printed,
  exit 1 with an `ERROR:` message on an invalid input.
- `odatse.main(["input.toml"])` returns the result dict
  (`{'x': ..., 'fx': ..., 'x0': ...}`).
- `pytest tests/unit`: 129 passed, 4 skipped (no new failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)