### PR TITLE
Run parallel_solver tests against the source tree instead of the installed package

### DIFF
--- a/tests/parallel_solver/parallel_solver.py
+++ b/tests/parallel_solver/parallel_solver.py
@@ -5,9 +5,15 @@
 # Problem: evaluate Himmelblau function in all solver processes and take the average
 #
 
+# Prefer the source tree over any installed odatse package, so that the tests
+# always exercise the working copy. The path must be absolute because odatse
+# changes the working directory during a run.
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "src")))
+
 from typing import Optional, Sequence
 
-import os, time, argparse
+import time, argparse
 import numpy as np
 from mpi4py import MPI
 import odatse


### PR DESCRIPTION
## Summary

`tests/parallel_solver/parallel_solver.py` imported `odatse` by package name, so
these 15 tests silently exercised whatever `odatse` package was installed in the
environment rather than the checkout. All other test directories run
`src/odatse_main.py` directly and therefore always test the working copy.

With a stale install (e.g. 3.2.1) present, the parallel tests fail with errors
such as `initialize() takes 0 positional arguments but 1 was given` even though
the checkout itself is fine — or worse, they can pass while never testing the
new code.

## Changes

- Insert the absolute path of `src/` at the front of `sys.path` at the top of
  `tests/parallel_solver/parallel_solver.py`, following the same pattern already
  used by `tests/unit/conftest.py`.
- The path is made absolute because odatse changes the working directory during
  a run (`os.chdir` in `algorithm/_algorithm.py`), and on Python ≤ 3.10
  `__file__` of a directly executed script can be relative.

This works both via `ctest` and when running `sh do.sh` manually in each test
directory.

## Verification

- Placed a dummy stale `odatse` package on `PYTHONPATH` (simulating an old
  install) and ran `tests/parallel_solver/mapper_grid/do.sh`: the source tree
  is now imported and the test passes; before this change the dummy package won
  the import.
- Ran `tests/parallel_solver/random_search/do.sh` in a normal environment:
  TEST PASS.

Closes #78.

🤖 Generated with [Claude Code](https://claude.com/claude-code)