### PR TITLE
Replace coreutils timeout dependency with a Python helper in resume tests

### DIFF
--- a/tests/mapper_resume/do.sh
+++ b/tests/mapper_resume/do.sh
@@ -1,12 +1,8 @@
 #!/bin/sh
 
-if [ "$(uname)" = "Darwin" ]; then
-  which gtimeout > /dev/null 2>&1 || { echo "gtimeout is not installed"; echo "Please install gtimeout using 'brew install coreutils'"; exit 1; }
-  TIMEOUT="gtimeout"
-else
-  which timeout > /dev/null 2>&1 || { echo "timeout is not installed"; exit 1; }
-  TIMEOUT="timeout"
-fi
+# Use a Python replacement for timeout(1), which is not available on macOS
+# without GNU coreutils
+TIMEOUT="${PYTHON:-python3} ../test_utilities/timeout.py"
 
 
 export PYTHONUNBUFFERED=1

--- a/tests/test_utilities/timeout.py
+++ b/tests/test_utilities/timeout.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+# Minimal cross-platform replacement for coreutils timeout(1), so that the
+# checkpoint/resume tests do not require GNU coreutils (gtimeout) on macOS.
+#
+# Usage: python3 timeout.py DURATION COMMAND [ARG]...
+# DURATION is a number of seconds, optionally with an s/m/h suffix as in
+# timeout(1). Exits with the command's exit code, or 124 if the timeout
+# fired (SIGTERM first, SIGKILL after a short grace period).
+
+import subprocess
+import sys
+
+KILL_GRACE = 5.0
+
+def parse_duration(text):
+    units = {"s": 1, "m": 60, "h": 3600}
+    scale = units.get(text[-1:], None)
+    if scale is None:
+        return float(text)
+    return float(text[:-1]) * scale
+
+def main():
+    if len(sys.argv) < 3:
+        print(f"Usage: {sys.argv[0]} DURATION COMMAND [ARG]...", file=sys.stderr)
+        return 125
+    try:
+        duration = parse_duration(sys.argv[1])
+    except ValueError:
+        print(f"invalid duration: {sys.argv[1]}", file=sys.stderr)
+        return 125
+    try:
+        p = subprocess.Popen(sys.argv[2:])
+    except FileNotFoundError as e:
+        print(e, file=sys.stderr)
+        return 127
+    try:
+        return p.wait(timeout=duration)
+    except subprocess.TimeoutExpired:
+        p.terminate()
+        try:
+            p.wait(timeout=KILL_GRACE)
+        except subprocess.TimeoutExpired:
+            p.kill()
+            p.wait()
+        return 124
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/ttopt_resume/do.sh
+++ b/tests/ttopt_resume/do.sh
@@ -20,13 +20,9 @@
 #
 # Pass condition : output1/res.txt == output2/res.txt
 
-if [ "$(uname)" = "Darwin" ]; then
-  which gtimeout > /dev/null 2>&1 || { echo "gtimeout is not installed"; echo "Please install gtimeout using 'brew install coreutils'"; exit 1; }
-  TIMEOUT="gtimeout"
-else
-  which timeout > /dev/null 2>&1 || { echo "timeout is not installed"; exit 1; }
-  TIMEOUT="timeout"
-fi
+# Use a Python replacement for timeout(1), which is not available on macOS
+# without GNU coreutils
+TIMEOUT="${PYTHON:-python3} ../test_utilities/timeout.py"
 
 export PYTHONUNBUFFERED=1
 

--- a/tests/ttopt_resume/do.sh
+++ b/tests/ttopt_resume/do.sh
@@ -30,8 +30,12 @@ CMD="${PYTHON:-python3} ../../src/odatse_main.py"
 # CMD="mpiexec -np 2 ${PYTHON:-python3} ../../src/odatse_main.py"
 
 # --- Part 1: initial run, interrupted by timeout ---
+# The timeout must fire after the first checkpoint (~8 s: end of the first
+# double sweep) but before the run completes (~10 s). 9.5 s sits in the
+# middle of that window; 8 s was right at its lower edge and failed
+# intermittently.
 rm -rf output1
-time ${TIMEOUT} 8s $CMD input1.toml
+time ${TIMEOUT} 9.5s $CMD input1.toml
 
 # Verify that a checkpoint file was created before the timeout fired
 if [ ! -f output1/0/status.pickle ]; then


### PR DESCRIPTION
## Summary

`tests/mapper_resume/do.sh` and `tests/ttopt_resume/do.sh` depended on the GNU
`timeout` command, which is not available on macOS without installing coreutils
(`gtimeout` via Homebrew). Without it the two tests aborted with only a short
notice, silently dropping checkpoint/resume coverage on macOS.

## Changes

### 1. Python replacement for `timeout(1)` (d777e49)

- Add `tests/test_utilities/timeout.py`, a minimal cross-platform replacement
  for coreutils `timeout(1)` built on `subprocess`:
  - sends SIGTERM on expiry (same default signal as `timeout(1)`), SIGKILL
    after a 5 s grace period,
  - `timeout(1)`-compatible exit codes (124 on timeout, 125 on usage error,
    127 on command not found, otherwise the command's exit code),
  - accepts durations with an `s`/`m`/`h` suffix (e.g. `12s`) as used by the
    test scripts.
- Use the helper unconditionally on all platforms in both `do.sh` scripts,
  removing the `uname` branch. Python 3 is already a hard requirement of the
  test suite, so this adds no new dependency, and CI (Linux) and local runs
  (macOS) now exercise the same code path.

### 2. Fix a pre-existing flakiness in ttopt_resume (2dd7f73)

While verifying the change, `ttopt_resume` failed with "Checkpoint file not
found". Measurement showed this is a pre-existing timing margin problem,
independent of the new helper (it reproduces with `gtimeout` as well):

- first checkpoint (end of the first double sweep): ~7.85 s
  (dominated by the 0.02 s/eval solver delay, so nearly machine-independent),
- uninterrupted completion: ~10.1 s.

The timeout must fire inside the (7.85 s, 10.1 s) window, but the previous
8 s sat only ~0.15 s above the lower edge — a near coin flip. Moved it to
9.5 s, close to the middle of the window. (`mapper_resume` is fine: first
checkpoint ~8 s, completion ~24 s, timeout 12 s.)

## Verification

- Unit-checked the helper's exit codes: 124 on timeout, exit-code
  passthrough, 127 on command not found, 125 on invalid duration.
- `mapper_resume/do.sh`: TEST PASS.
- `ttopt_resume/do.sh`: TEST PASS, three consecutive runs.

## Note for future work

As long as the interruption uses a fixed timeout, `ttopt_resume` retains some
sensitivity to machine speed. A more robust approach would be a helper that
watches for the checkpoint file to appear and then terminates the run,
removing the timing dependence entirely. This could be filed as a separate
issue.

Closes #79.

🤖 Generated with [Claude Code](https://claude.com/claude-code)