### PR TITLE
Add dual_annealing method to global_search and refactor

### DIFF
--- a/doc/en/source/algorithm/global_search.rst
+++ b/doc/en/source/algorithm/global_search.rst
@@ -5,6 +5,7 @@ Global optimization ``global_search``
 .. _scipy.optimize.differential_evolution: https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.differential_evolution.html
 .. _scipy.optimize.shgo: https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.shgo.html
 .. _scipy.optimize.direct: https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.direct.html
+.. _scipy.optimize.dual_annealing: https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.dual_annealing.html
 
 ``global_search`` minimizes :math:`f(x)` using the global optimization
 routines of scipy.optimize.
@@ -24,6 +25,10 @@ The following methods are currently available:
   a deterministic method that partitions the search region into
   hyperrectangles and preferentially subdivides those that are promising
   and large. It uses no random numbers and is fully reproducible.
+- dual annealing (`scipy.optimize.dual_annealing`_):
+  a stochastic method based on generalized simulated annealing (GSA),
+  combining an annealing-driven global search with local optimizations
+  started from accepted points.
 
 The search region is defined by ``min_list`` / ``max_list`` of
 ``[algorithm.param]`` and passed as the ``bounds`` argument of scipy.
@@ -46,9 +51,9 @@ generation is ``popsize`` x dimension, and the total is roughly bounded by
 convergence). The local refinements of shgo (its internal local
 optimizations) run serially on rank 0.
 
-direct does not support parallel evaluation and runs serially on rank 0
-(the other ranks stay idle; the solver-side parallelism ``nsolve`` within
-each point remains effective).
+direct and dual annealing do not support parallel evaluation and run
+serially on rank 0 (the other ranks stay idle; the solver-side parallelism
+``nsolve`` within each point remains effective).
 
 Preparation
 ~~~~~~~~~~~
@@ -106,7 +111,8 @@ be set.
 
   Description: Name of the optimization method (case-insensitive).
   "DE" or "differential_evolution" selects differential evolution;
-  "shgo" selects shgo; "direct" selects direct.
+  "shgo" selects shgo; "direct" selects direct; "dual_annealing" selects
+  dual annealing.
 
 - other parameters
 
@@ -125,6 +131,12 @@ be set.
   - direct: ``maxfun``, ``maxiter``, ``eps``, ``locally_biased``,
     ``len_tol``, ``vol_tol``, ... direct is also deterministic and does
     not use random numbers.
+  - dual annealing: ``maxiter``, ``maxfun``, ``initial_temp``,
+    ``restart_temp_ratio``, ``visit``, ``accept``, ``no_local_search``,
+    ``x0``, ... The sub-table
+    ``[algorithm.global_search.minimizer_kwargs]`` is passed as the
+    ``minimizer_kwargs`` argument of the local optimizations. The random
+    numbers are initialized from ``seed`` in the ``[algorithm]`` section.
 
 Example:
 
@@ -160,6 +172,12 @@ Remarks
 - direct requires scipy >= 1.9. Since its refinement near the optimum is
   slow, a useful workflow is to locate the basin with direct and then
   refine with minsearch.
+- By default, dual annealing runs local optimizations (L-BFGS-B) during
+  the annealing. Their gradients are evaluated by numerical
+  differentiation, so the number of evaluations can grow large when solver
+  evaluations are expensive. Setting ``no_local_search = true`` turns it
+  into classical simulated annealing without local optimizations.
+  ``maxfun`` (default: 1e7) limits the total number of evaluations.
 - Constraints given by ``[runner.limitation]`` are handled by treating the
   objective function value of violating points as infinity.
 - Restarting (checkpointing) is not supported.
@@ -167,8 +185,8 @@ Remarks
 Output files
 ~~~~~~~~~~~~~~~~~
 
-``GenerationData.txt`` / ``IterationData.txt``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+``GenerationData.txt`` / ``IterationData.txt`` / ``MinimumData.txt``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Records the best point of each iteration (rank 0 only).
 For differential evolution, ``GenerationData.txt`` contains the generation
@@ -177,6 +195,11 @@ objective function, and the convergence measure, in that order.
 For shgo and direct, ``IterationData.txt`` contains the iteration number,
 the values of the variables of the best point, and the value of the
 objective function.
+For dual annealing, a row is appended to ``MinimumData.txt`` each time a
+better minimum is found, containing the index, the values of the
+variables, the value of the objective function, and the context (0: found
+during annealing, 1: found during a local search, 2: found in the dual
+annealing process), in that order.
 
 ``LocalMinimaData.txt``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/en/source/input/algorithm.rst
+++ b/doc/en/source/input/algorithm.rst
@@ -14,7 +14,7 @@ The ``name`` determines the type of algorithm. Each parameter is defined for eac
 
   - ``minsearch`` : Minimum value search using Nelder-Mead method
 
-  - ``global_search`` : Global optimization using the scipy.optimize routines (differential evolution, shgo, direct)
+  - ``global_search`` : Global optimization using the scipy.optimize routines (differential evolution, shgo, direct, dual annealing)
 
   - ``mapper`` : Grid search
 

--- a/doc/ja/source/algorithm/global_search.rst
+++ b/doc/ja/source/algorithm/global_search.rst
@@ -5,6 +5,7 @@
 .. _scipy.optimize.differential_evolution: https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.differential_evolution.html
 .. _scipy.optimize.shgo: https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.shgo.html
 .. _scipy.optimize.direct: https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.direct.html
+.. _scipy.optimize.dual_annealing: https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.dual_annealing.html
 
 ``global_search`` は scipy.optimize の大域最適化ルーチンを用いて
 :math:`f(x)` の最小化を行います。
@@ -20,6 +21,9 @@
 - direct (DIviding RECTangles, `scipy.optimize.direct`_):
   探索領域を超矩形に分割し、有望かつ大きい矩形を優先的に細分化していく
   決定論的手法です。乱数を使用せず、完全な再現性があります。
+- dual annealing (`scipy.optimize.dual_annealing`_):
+  一般化シミュレーテッドアニーリング (GSA) に基づく確率的手法です。
+  焼きなましによる大域探索に、受理された点からの局所最適化を組み合わせます。
 
 探索範囲は ``[algorithm.param]`` の ``min_list`` / ``max_list`` で規定され、
 scipy の ``bounds`` 引数として渡されます。初期値 (``initial_list``) は使用しません。
@@ -39,7 +43,8 @@ shgo ではサンプリング段階の評価点が、まとめて各ランクに
 (収束判定により早く終了する場合があります)。
 shgo の局所精錬(内部の局所最適化)はランク 0 上で逐次実行されます。
 
-direct は並列評価に対応していないため、ランク 0 上で逐次実行されます
+direct と dual annealing は並列評価に対応していないため、ランク 0 上で
+逐次実行されます
 (他のランクは待機します。各点内のソルバー並列 ``nsolve`` は有効です)。
 
 前準備
@@ -95,7 +100,7 @@ direct は並列評価に対応していないため、ランク 0 上で逐次�
 
   説明: 最適化手法の名前(大文字小文字は区別しません)。
   "DE" または "differential_evolution" で差分進化法、"shgo" で shgo、
-  "direct" で direct を選択します。
+  "direct" で direct、"dual_annealing" で dual annealing を選択します。
 
 - その他のパラメータ
 
@@ -113,6 +118,12 @@ direct は並列評価に対応していないため、ランク 0 上で逐次�
     shgo は決定論的で乱数を使用しません。
   - direct: ``maxfun``, ``maxiter``, ``eps``, ``locally_biased``,
     ``len_tol``, ``vol_tol`` など。direct も決定論的で乱数を使用しません。
+  - dual annealing: ``maxiter``, ``maxfun``, ``initial_temp``,
+    ``restart_temp_ratio``, ``visit``, ``accept``, ``no_local_search``,
+    ``x0`` など。サブテーブル
+    ``[algorithm.global_search.minimizer_kwargs]`` は局所最適化に渡す
+    ``minimizer_kwargs`` 引数となります。乱数は ``[algorithm]`` セクションの
+    ``seed`` から初期化されます。
 
 設定例:
 
@@ -145,6 +156,11 @@ direct は並列評価に対応していないため、ランク 0 上で逐次�
   それ未満のバージョンで MPI 並列実行した場合は開始前にエラーで停止します。
 - direct は scipy >= 1.9 が必要です。また、最適点近傍の精密化が遅いため、
   direct で当たりをつけてから minsearch で磨く使い方が有効です。
+- dual annealing はデフォルトで焼きなまし中に局所最適化 (L-BFGS-B 法) を
+  実行します。勾配は数値差分により評価されるため、ソルバーの評価コストが
+  大きい場合は評価回数が増大します。``no_local_search = true`` とすると
+  局所最適化を行わない古典的な焼きなましになります。
+  ``maxfun`` (デフォルト: 1e7) で総評価回数を制限できます。
 - ``[runner.limitation]`` による制約条件は、制約を満たさない点の目的関数値を
   無限大とみなす方法で処理されます。
 - リスタート(チェックポイント)には対応していません。
@@ -152,14 +168,17 @@ direct は並列評価に対応していないため、ランク 0 上で逐次�
 出力ファイル
 ~~~~~~~~~~~~~~~~~
 
-``GenerationData.txt`` / ``IterationData.txt``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+``GenerationData.txt`` / ``IterationData.txt`` / ``MinimumData.txt``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 反復ごとの最良点の情報を出力します(ランク 0 のみ)。
 差分進化法では ``GenerationData.txt`` に、世代番号、最良点の変数の値、
 目的関数の値、収束度 (convergence) がこの順に出力されます。
 shgo / direct では ``IterationData.txt`` に、反復番号、最良点の変数の値、
 目的関数の値がこの順に出力されます。
+dual annealing では ``MinimumData.txt`` に、より良い最小値が見つかるたびに、
+番号、変数の値、目的関数の値、context (0: 焼きなまし中に発見、
+1: 局所最適化中に発見、2: dual annealing 過程で発見) がこの順に出力されます。
 
 ``LocalMinimaData.txt``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/ja/source/input/algorithm.rst
+++ b/doc/ja/source/input/algorithm.rst
@@ -14,7 +14,7 @@
 
   - ``minsearch``: Nelder-Mead法による最小値探索
 
-  - ``global_search``: scipy.optimize の大域最適化ルーチン(差分進化法, shgo, direct)による探索
+  - ``global_search``: scipy.optimize の大域最適化ルーチン(差分進化法, shgo, direct, dual annealing)による探索
 
   - ``mapper``: グリッド探索
 

--- a/src/odatse/algorithm/global_search.py
+++ b/src/odatse/algorithm/global_search.py
@@ -11,7 +11,7 @@ import inspect
 import time
 
 import numpy as np
-from scipy.optimize import differential_evolution, shgo
+from scipy.optimize import differential_evolution, shgo, dual_annealing
 
 try:
     from scipy.optimize import direct
@@ -35,6 +35,7 @@ class Algorithm(odatse.algorithm.AlgorithmBase):
     * "DE" / "differential_evolution": scipy.optimize.differential_evolution
     * "shgo": scipy.optimize.shgo
     * "direct": scipy.optimize.direct
+    * "dual_annealing": scipy.optimize.dual_annealing
 
     All other entries of the section are passed verbatim as arguments of the
     selected scipy routine; argument names the routine does not accept abort
@@ -46,7 +47,9 @@ class Algorithm(odatse.algorithm.AlgorithmBase):
     a time) to all algorithm ranks; the other ranks run an evaluation-server
     loop, evaluating their share of the points with their own solver group.
     This composes with solver-side parallelism (``nsolve``): the total
-    parallelism is algsize (points) x nsolve (per point).
+    parallelism is algsize (points) x nsolve (per point). The direct and
+    dual_annealing methods do not support parallel evaluation and run
+    entirely on rank 0.
     """
 
     # method name aliases (case-insensitive) -> scipy routine name
@@ -55,10 +58,11 @@ class Algorithm(odatse.algorithm.AlgorithmBase):
         "differential_evolution": "differential_evolution",
         "shgo": "shgo",
         "direct": "direct",
+        "dual_annealing": "dual_annealing",
     }
 
     # methods implemented so far
-    _IMPLEMENTED = {"differential_evolution", "shgo", "direct"}
+    _IMPLEMENTED = {"differential_evolution", "shgo", "direct", "dual_annealing"}
 
     # arguments of the scipy routines managed by ODAT-SE itself; rejected if
     # the user sets them in [algorithm.global_search]
@@ -129,13 +133,15 @@ class Algorithm(odatse.algorithm.AlgorithmBase):
         if key not in self._METHOD_ALIASES:
             raise ValueError(
                 f"algorithm.global_search.method '{method}' is unknown; "
-                f"available: DE (differential_evolution), shgo, direct"
+                f"available: DE (differential_evolution), shgo, direct, "
+                f"dual_annealing"
             )
         self.method = self._METHOD_ALIASES[key]
         if self.method not in self._IMPLEMENTED:
             raise NotImplementedError(
                 f"algorithm.global_search.method '{method}' is not implemented yet; "
-                f"currently implemented: DE (differential_evolution), shgo, direct"
+                f"currently implemented: DE (differential_evolution), shgo, direct, "
+                f"dual_annealing"
             )
         if self.method == "direct" and direct is None:
             raise RuntimeError(
@@ -159,6 +165,7 @@ class Algorithm(odatse.algorithm.AlgorithmBase):
             "differential_evolution": differential_evolution,
             "shgo": shgo,
             "direct": direct,
+            "dual_annealing": dual_annealing,
         }[self.method]
         accepted = set(inspect.signature(scipy_func).parameters)
         unknown = set(self.opt_params) - accepted
@@ -326,6 +333,19 @@ class Algorithm(odatse.algorithm.AlgorithmBase):
             print("iteration {}: best x={}, fun={}".format(len(iter_history), xk, fun))
             iter_history.append(row)
 
+        def _cb_da(x, f, context):
+            """
+            Callback for dual_annealing, invoked each time a new best
+            minimum is found, as (x, f, context) with context 0 (found
+            during annealing), 1 (found during local search) or 2 (found
+            in the dual annealing process). f comes with the callback, so
+            no f_cache lookup is needed.
+            """
+            row = [len(iter_history), *x, float(f), int(context)]
+            print("minimum {}: x={}, fun={}, context={}".format(
+                len(iter_history), x, f, context))
+            iter_history.append(row)
+
         params = dict(self.opt_params)
         if self.method == "differential_evolution":
             # deferred updating evaluates a whole generation at a time, which
@@ -388,6 +408,26 @@ class Algorithm(odatse.algorithm.AlgorithmBase):
                         callback=_cb,
                         **params,
                     )
+                elif self.method == "dual_annealing":
+                    # dual_annealing runs a single sequential annealing
+                    # chain and does not support parallel evaluation; it
+                    # runs entirely on rank 0 while the other ranks stay
+                    # idle in the server loop
+                    if nprocs > 1:
+                        print("Warning: method 'dual_annealing' does not "
+                              "support parallel evaluation; algorithm ranks "
+                              "> 0 stay idle")
+                    optres = dual_annealing(
+                        _f_calc,
+                        bounds,
+                        # as for differential_evolution: the seed path
+                        # accepts the RandomState across all supported
+                        # scipy versions, while the new rng= argument of
+                        # scipy >= 1.15 does not
+                        seed=self.rng,
+                        callback=_cb_da,
+                        **params,
+                    )
                 else:  # pragma: no cover - guarded in __init__
                     raise RuntimeError(f"method {self.method} not implemented")
             except BaseException:
@@ -448,6 +488,10 @@ class Algorithm(odatse.algorithm.AlgorithmBase):
         if odatse.mpi.algrank() == 0:
             if self.method == "differential_evolution":
                 iter_file, iter_header = "GenerationData.txt", "#gen {} R-factor convergence\n"
+            elif self.method == "dual_annealing":
+                # rows are recorded when a new best minimum is found, not
+                # per iteration
+                iter_file, iter_header = "MinimumData.txt", "#no {} R-factor context\n"
             else:
                 iter_file, iter_header = "IterationData.txt", "#iter {} R-factor\n"
             with open(iter_file, "w") as fp:

--- a/src/odatse/algorithm/global_search.py
+++ b/src/odatse/algorithm/global_search.py
@@ -6,7 +6,8 @@
 # This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
 # If a copy of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from typing import Union, Optional, TYPE_CHECKING
+from typing import Callable, Union, Optional, TYPE_CHECKING
+from dataclasses import dataclass
 import inspect
 import time
 
@@ -25,6 +26,107 @@ if TYPE_CHECKING:
     from mpi4py import MPI
 
 
+@dataclass(frozen=True)
+class _Method:
+    """Declarative description of one scipy.optimize global routine.
+
+    All per-method differences of the algorithm live here, so that adding
+    a method amounts to adding one entry to the _METHODS table (plus tests
+    and documentation); __init__, _run and _output_results are table-driven.
+    """
+
+    # the scipy routine, or None when the installed scipy does not provide
+    # it; requires then names the requirement reported to the user
+    func: Optional[Callable]
+    requires: Optional[str]
+    # accepted method names besides the canonical one (case-insensitive)
+    aliases: tuple
+    # whether the routine takes random numbers, passed as seed=self.rng:
+    # the seed path accepts a RandomState across all supported scipy
+    # versions, while the new rng= argument of scipy >= 1.15 does not
+    uses_seed: bool
+    # whether candidate points can be evaluated in parallel through the
+    # workers= hook; otherwise the routine runs entirely on rank 0 and the
+    # other algorithm ranks stay idle
+    supports_workers: bool
+    # per-iteration callback signature: "xk" for callback(xk[, convergence])
+    # (the old-style signature supported by every scipy version in the
+    # supported range), "x_f_context" for callback(x, f, context) invoked
+    # on every new best minimum (dual_annealing)
+    callback_style: str
+    # ODAT-SE defaults for the routine; user-specified values take precedence
+    defaults: dict
+    # iteration-history output file and its header ({} receives the labels)
+    iter_file: str
+    iter_header: str
+
+
+_METHODS = {
+    "differential_evolution": _Method(
+        func=differential_evolution,
+        requires=None,
+        aliases=("de",),
+        uses_seed=True,
+        supports_workers=True,
+        callback_style="xk",
+        # deferred updating evaluates a whole generation at a time, which
+        # the parallel evaluation requires; it is also scipy's own
+        # fallback when workers is set, so make it the default to keep
+        # serial and parallel runs identical
+        defaults={"updating": "deferred"},
+        iter_file="GenerationData.txt",
+        iter_header="#gen {} R-factor convergence\n",
+    ),
+    "shgo": _Method(
+        func=shgo,
+        requires=None,
+        aliases=(),
+        # deterministic; workers parallelizes the sampling-phase
+        # evaluations (scipy >= 1.11), while the local refinements run
+        # serially on rank 0
+        uses_seed=False,
+        supports_workers=True,
+        callback_style="xk",
+        defaults={},
+        iter_file="IterationData.txt",
+        iter_header="#iter {} R-factor\n",
+    ),
+    "direct": _Method(
+        func=direct,
+        requires="scipy >= 1.9",
+        aliases=(),
+        # deterministic and strictly sequential
+        uses_seed=False,
+        supports_workers=False,
+        callback_style="xk",
+        defaults={},
+        iter_file="IterationData.txt",
+        iter_header="#iter {} R-factor\n",
+    ),
+    "dual_annealing": _Method(
+        func=dual_annealing,
+        requires=None,
+        aliases=(),
+        # a single sequential annealing chain
+        uses_seed=True,
+        supports_workers=False,
+        callback_style="x_f_context",
+        defaults={},
+        # rows are recorded when a new best minimum is found, not per
+        # iteration
+        iter_file="MinimumData.txt",
+        iter_header="#no {} R-factor context\n",
+    ),
+}
+
+# method name (case-insensitive) -> canonical method name
+_METHOD_ALIASES = {
+    alias: name
+    for name, m in _METHODS.items()
+    for alias in (name,) + m.aliases
+}
+
+
 class Algorithm(odatse.algorithm.AlgorithmBase):
     """
     Algorithm class for global optimization using scipy.optimize routines.
@@ -36,6 +138,10 @@ class Algorithm(odatse.algorithm.AlgorithmBase):
     * "shgo": scipy.optimize.shgo
     * "direct": scipy.optimize.direct
     * "dual_annealing": scipy.optimize.dual_annealing
+
+    The per-method differences (aliases, seed and workers handling,
+    callback signature, defaults, output files) are described by the
+    module-level _METHODS table.
 
     All other entries of the section are passed verbatim as arguments of the
     selected scipy routine; argument names the routine does not accept abort
@@ -52,18 +158,6 @@ class Algorithm(odatse.algorithm.AlgorithmBase):
     entirely on rank 0.
     """
 
-    # method name aliases (case-insensitive) -> scipy routine name
-    _METHOD_ALIASES = {
-        "de": "differential_evolution",
-        "differential_evolution": "differential_evolution",
-        "shgo": "shgo",
-        "direct": "direct",
-        "dual_annealing": "dual_annealing",
-    }
-
-    # methods implemented so far
-    _IMPLEMENTED = {"differential_evolution", "shgo", "direct", "dual_annealing"}
-
     # arguments of the scipy routines managed by ODAT-SE itself; rejected if
     # the user sets them in [algorithm.global_search]
     _RESERVED = {
@@ -79,6 +173,7 @@ class Algorithm(odatse.algorithm.AlgorithmBase):
 
     # optimization method and its parameters
     method: str
+    _method: _Method
     opt_params: dict
 
     # results
@@ -130,22 +225,20 @@ class Algorithm(odatse.algorithm.AlgorithmBase):
 
         method = str(info_gs.get("method", "DE"))
         key = method.lower()
-        if key not in self._METHOD_ALIASES:
+        if key not in _METHOD_ALIASES:
+            available = ", ".join(
+                "{} ({})".format(m.aliases[0], name) if m.aliases else name
+                for name, m in _METHODS.items())
             raise ValueError(
                 f"algorithm.global_search.method '{method}' is unknown; "
-                f"available: DE (differential_evolution), shgo, direct, "
-                f"dual_annealing"
+                f"available: {available}"
             )
-        self.method = self._METHOD_ALIASES[key]
-        if self.method not in self._IMPLEMENTED:
-            raise NotImplementedError(
-                f"algorithm.global_search.method '{method}' is not implemented yet; "
-                f"currently implemented: DE (differential_evolution), shgo, direct, "
-                f"dual_annealing"
-            )
-        if self.method == "direct" and direct is None:
+        self.method = _METHOD_ALIASES[key]
+        self._method = _METHODS[self.method]
+        if self._method.func is None:
             raise RuntimeError(
-                "algorithm.global_search.method 'direct' requires scipy >= 1.9"
+                "algorithm.global_search.method '{}' requires {}".format(
+                    method, self._method.requires)
             )
 
         # forward all remaining entries verbatim as arguments of the scipy
@@ -161,13 +254,7 @@ class Algorithm(odatse.algorithm.AlgorithmBase):
         # scipy before anything runs, instead of catching TypeError around
         # the optimizer call: a TypeError raised at runtime (by the solver,
         # a callback, ...) must not be misreported as an input-file mistake
-        scipy_func = {
-            "differential_evolution": differential_evolution,
-            "shgo": shgo,
-            "direct": direct,
-            "dual_annealing": dual_annealing,
-        }[self.method]
-        accepted = set(inspect.signature(scipy_func).parameters)
+        accepted = set(inspect.signature(self._method.func).parameters)
         unknown = set(self.opt_params) - accepted
         if unknown:
             raise ValueError(
@@ -346,90 +433,43 @@ class Algorithm(odatse.algorithm.AlgorithmBase):
                 len(iter_history), x, f, context))
             iter_history.append(row)
 
+        m = self._method
         params = dict(self.opt_params)
-        if self.method == "differential_evolution":
-            # deferred updating evaluates a whole generation at a time, which
-            # the parallel evaluation requires; it is also scipy's own
-            # fallback when workers is set, so make it the default to keep
-            # serial and parallel runs identical (a user-specified value
-            # still takes precedence)
-            params.setdefault("updating", "deferred")
+        for k, v in m.defaults.items():
+            params.setdefault(k, v)
 
         bounds = list(zip(min_list, max_list))
 
-        # inject the MPI map only when there are ranks to distribute to:
-        # passing workers= unconditionally would make even serial runs
-        # require a scipy version that supports the keyword (shgo gained it
-        # in 1.11). Serial DE results stay identical either way because
-        # updating='deferred' evaluates the population in the same order as
-        # the workers hook does.
-        workers_kwargs = {"workers": _workers} if nprocs > 1 else {}
+        extra_kwargs = {}
+        if m.supports_workers and nprocs > 1:
+            # inject the MPI map only when there are ranks to distribute
+            # to: passing workers= unconditionally would make even serial
+            # runs require a scipy version that supports the keyword (shgo
+            # gained it in 1.11). Serial DE results stay identical either
+            # way because updating='deferred' evaluates the population in
+            # the same order as the workers hook does.
+            extra_kwargs["workers"] = _workers
+        if m.uses_seed:
+            extra_kwargs["seed"] = self.rng
+        callback = _cb_da if m.callback_style == "x_f_context" else _cb
 
         time_sta = time.perf_counter()
         if rank == 0:
+            if not m.supports_workers and nprocs > 1:
+                print("Warning: method '{}' does not support parallel "
+                      "evaluation; algorithm ranks > 0 stay idle"
+                      .format(self.method))
             # argument names were validated against the scipy signature in
             # __init__, so a TypeError here is a genuine runtime failure and
             # propagates unchanged (issue #76)
             try:
-                if self.method == "differential_evolution":
-                    optres = differential_evolution(
-                        _f_calc,
-                        bounds,
-                        # self.rng is a RandomState; the seed path accepts
-                        # it across all supported scipy versions, while
-                        # the new rng= argument of scipy >= 1.15 does not
-                        seed=self.rng,
-                        callback=_cb,
-                        **workers_kwargs,
-                        **params,
-                    )
-                elif self.method == "shgo":
-                    # shgo is deterministic and takes no seed; workers
-                    # parallelizes the sampling-phase evaluations, while
-                    # the local refinements run serially through _f_calc
-                    optres = shgo(
-                        _f_calc,
-                        bounds,
-                        callback=_cb,
-                        **workers_kwargs,
-                        **params,
-                    )
-                elif self.method == "direct":
-                    # direct is deterministic and does not support
-                    # parallel evaluation; it runs entirely on rank 0
-                    # while the other ranks stay idle in the server loop
-                    if nprocs > 1:
-                        print("Warning: method 'direct' does not support "
-                              "parallel evaluation; algorithm ranks > 0 "
-                              "stay idle")
-                    optres = direct(
-                        _f_calc,
-                        bounds,
-                        callback=_cb,
-                        **params,
-                    )
-                elif self.method == "dual_annealing":
-                    # dual_annealing runs a single sequential annealing
-                    # chain and does not support parallel evaluation; it
-                    # runs entirely on rank 0 while the other ranks stay
-                    # idle in the server loop
-                    if nprocs > 1:
-                        print("Warning: method 'dual_annealing' does not "
-                              "support parallel evaluation; algorithm ranks "
-                              "> 0 stay idle")
-                    optres = dual_annealing(
-                        _f_calc,
-                        bounds,
-                        # as for differential_evolution: the seed path
-                        # accepts the RandomState across all supported
-                        # scipy versions, while the new rng= argument of
-                        # scipy >= 1.15 does not
-                        seed=self.rng,
-                        callback=_cb_da,
-                        **params,
-                    )
-                else:  # pragma: no cover - guarded in __init__
-                    raise RuntimeError(f"method {self.method} not implemented")
+                optres = m.func(
+                    _f_calc,
+                    bounds,
+                    callback=callback,
+                    **extra_kwargs,
+                    **params,
+                )
             except BaseException:
                 # release the evaluation servers before propagating, so that
                 # every rank reaches the consensus collective in run()
@@ -486,16 +526,8 @@ class Algorithm(odatse.algorithm.AlgorithmBase):
                 fp.write(" ".join(map(str, v)) + "\n")
 
         if odatse.mpi.algrank() == 0:
-            if self.method == "differential_evolution":
-                iter_file, iter_header = "GenerationData.txt", "#gen {} R-factor convergence\n"
-            elif self.method == "dual_annealing":
-                # rows are recorded when a new best minimum is found, not
-                # per iteration
-                iter_file, iter_header = "MinimumData.txt", "#no {} R-factor context\n"
-            else:
-                iter_file, iter_header = "IterationData.txt", "#iter {} R-factor\n"
-            with open(iter_file, "w") as fp:
-                fp.write(iter_header.format(" ".join(label_list)))
+            with open(self._method.iter_file, "w") as fp:
+                fp.write(self._method.iter_header.format(" ".join(label_list)))
                 for v in self.iter_history:
                     fp.write(" ".join(map(str, v)) + "\n")
 

--- a/tests/unit/test_global_search.py
+++ b/tests/unit/test_global_search.py
@@ -202,6 +202,55 @@ def test_direct_unknown_param_raises(tmp_path, monkeypatch):
                            run=False)
 
 
+def test_dual_annealing_converges(tmp_path, monkeypatch):
+    """dual_annealing finds the minimum of a quadratic function. Like
+    direct it runs entirely on rank 0; under MPI the other ranks stay idle
+    but still receive the broadcast result."""
+    monkeypatch.chdir(tmp_path)
+    record = []
+    alg = _run_global_search(
+        tmp_path, unit_list=[1.0, 1.0], record=record,
+        global_search_params={"method": "dual_annealing", "maxiter": 20,
+                              "maxfun": 2000})
+    assert alg.method == "dual_annealing"
+    np.testing.assert_allclose(alg.xopt, [0.0, 0.0], atol=1e-3)
+    assert alg.fopt < 1e-4
+    if odatse.mpi.algrank() == 0:
+        assert len(alg.iter_history) > 0
+        assert list(tmp_path.glob("**/MinimumData.txt"))
+        content = (tmp_path / "output" / "res.txt").read_text()
+        assert content.startswith("fx = ")
+        assert "None" not in content
+
+
+def test_dual_annealing_multimodal(tmp_path, monkeypatch):
+    """dual_annealing reaches the global minimum of the double-well
+    function."""
+    monkeypatch.chdir(tmp_path)
+    record = []
+
+    def double_well(x):
+        record.append(np.array(x, copy=True))
+        return float(((x[0] ** 2 - 4) ** 2) / 8.0 + 0.5 * x[0] - 2.0 + x[1] ** 2)
+
+    alg = _run_global_search(
+        tmp_path, unit_list=[1.0, 1.0], record=record, fn=double_well,
+        global_search_params={"method": "dual_annealing", "maxiter": 50,
+                              "maxfun": 4000})
+    assert alg.fopt < -2.0
+    assert alg.xopt[0] < 0.0
+
+
+def test_dual_annealing_unknown_param_raises(tmp_path, monkeypatch):
+    """fail-fast also applies to the dual_annealing argument list."""
+    monkeypatch.chdir(tmp_path)
+    with pytest.raises(ValueError, match="dual_annealing"):
+        _run_global_search(tmp_path, unit_list=[1.0, 1.0], record=[],
+                           global_search_params={"method": "dual_annealing",
+                                                 "no_such_param": 1},
+                           run=False)
+
+
 def test_method_aliases(tmp_path, monkeypatch):
     """"DE" (default), "de" and "differential_evolution" all select the DE
     routine."""
@@ -224,7 +273,8 @@ def test_unknown_method_raises(tmp_path, monkeypatch):
 def test_all_methods_recognized(tmp_path, monkeypatch):
     """Every documented method name resolves without NotImplementedError."""
     monkeypatch.chdir(tmp_path)
-    methods = [("DE", "differential_evolution"), ("shgo", "shgo")]
+    methods = [("DE", "differential_evolution"), ("shgo", "shgo"),
+               ("dual_annealing", "dual_annealing")]
     if global_search.direct is not None:
         methods.append(("direct", "direct"))
     for m, resolved in methods:


### PR DESCRIPTION
## Summary

This PR adds `scipy.optimize.dual_annealing` as a new method of the `global_search` algorithm, selected by `method = "dual_annealing"` in the `[algorithm.global_search]` section:

```toml
[algorithm.global_search]
method = "dual_annealing"
maxiter = 100
```

As with the other methods, all parameters other than `method` (`initial_temp`, `no_local_search`, `x0`, the `minimizer_kwargs` sub-table, ...) are passed verbatim to the scipy routine, with fail-fast validation of argument names against the installed scipy's signature.

## Behavior

- **MPI**: dual_annealing runs a single sequential annealing chain and does not support the parallel `workers=` hook. Like `direct`, it runs entirely on algorithm rank 0 with a warning; the other ranks stay idle in the evaluation-server loop. Solver-side parallelism (`nsolve`) remains effective.
- **Random numbers** are initialized from `[algorithm]` `seed` via the `seed=` path, which accepts the RandomState across all supported scipy versions (the `rng=` argument introduced in scipy 1.15 does not).
- **Output**: dual_annealing reports successively improved minima through its `(x, f, context)` callback rather than per-iteration best points, so these are written to a new file `MinimumData.txt` (index, variables, objective value, context) instead of `IterationData.txt`.
- No version guard is needed: `dual_annealing` has been available since scipy 1.2, the same as `shgo`, which is already imported unconditionally.

## Refactoring

The second commit replaces the per-method `if`/`elif` branches spread across `__init__`, `_run`, and `_output_results` with a declarative module-level `_METHODS` table. Each entry describes one routine (aliases, seed/workers handling, callback signature, defaults, output file), so adding a method now amounts to adding one table entry plus tests and documentation. No behavior change: outputs are bit-identical for a fixed seed.

## Documentation

The Japanese and English manuals are updated (method list, MPI behavior, input parameters, output files, and a remark on the evaluation cost of the numerical-gradient local searches and how to limit it with `no_local_search` / `maxfun`).

## Test

- Unit tests added: convergence on a quadratic function, reaching the global minimum of an asymmetric double-well, and fail-fast rejection of unknown parameters.
- All `global_search` unit tests pass serially and with `mpiexec -np 2`.
- Verified that the refactoring commit reproduces bit-identical `res.txt` / `MinimumData.txt` for a fixed seed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)